### PR TITLE
Add the records used by the dataweb to the archive

### DIFF
--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -151,7 +151,7 @@ record(longin, "$(P)RAWFRAMES")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(longin, "$(P)RAWFRAMES_PD")
@@ -160,7 +160,7 @@ record(longin, "$(P)RAWFRAMES_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)RAWFRAMESPD")
     field(SCAN, "I/O Intr")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(longin, "$(P)GOODFRAMES")
@@ -171,7 +171,7 @@ record(longin, "$(P)GOODFRAMES")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(longin, "$(P)GOODFRAMES_PD")
@@ -180,7 +180,7 @@ record(longin, "$(P)GOODFRAMES_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)GOODFRAMESPD")
     field(SCAN, "I/O Intr")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(longin, "$(P)RUNDURATION")
@@ -191,7 +191,7 @@ record(longin, "$(P)RUNDURATION")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "s")
-    info(archive, "VAL")
+    info(archive, "-30.0 VAL")
 }
 
 record(longin, "$(P)RUNDURATION_PD")
@@ -200,7 +200,7 @@ record(longin, "$(P)RUNDURATION_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)RUNDURATIONPD")
     field(SCAN, "I/O Intr")
-    info(archive, "VAL")
+    info(archive, "-30.0 VAL")
 }
 
 record(longin, "$(P)NUMTIMECHANNELS")
@@ -278,7 +278,7 @@ record(ai, "$(P)BEAMCURRENT")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "uA")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(ai, "$(P)TOTALUAMPS")
@@ -290,7 +290,7 @@ record(ai, "$(P)TOTALUAMPS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "uA hour")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(ai, "$(P)TOTALDAECOUNTS")
@@ -301,6 +301,7 @@ record(ai, "$(P)TOTALDAECOUNTS")
     field(PREC, "3")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
+    info(archive, "-5.0 VAL")
 	field(EGU, "count")
 }
 
@@ -335,7 +336,7 @@ record(ai, "$(P)COUNTRATE")
     field(SCAN, "I/O Intr")
 	field(EGU, "")
     info(INTEREST, "HIGH")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(ai, "$(P)EVENTMODEFRACTION")
@@ -358,6 +359,7 @@ record(ai, "$(P)GOODUAH")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "uA hour")
+    info(archive, "-5.0 VAL")
 }
 
 record(ai, "$(P)GOODUAH_PD")
@@ -368,6 +370,7 @@ record(ai, "$(P)GOODUAH_PD")
     field(PREC, "3")
     field(SCAN, "I/O Intr")
 	field(EGU, "uA hour")
+    info(archive, "-5.0 VAL")
 }
 
 record(bo, "$(P)BEGINRUN")
@@ -601,7 +604,7 @@ record(longin, "$(P)TOTALCOUNTS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "count")
-    info(archive, "VAL")
+    info(archive, "-5.0 VAL")
 }
 
 record(waveform, "$(P)DAESETTINGS")
@@ -690,7 +693,7 @@ record(ai, "$(P)VETOPC")
 	field(EGU, "%")
 # useful to log, but need a good deadband value or will get too much data
 	field(ADEL, 5.0)
-	info(archive, "VAL")
+	info(archive, "-5.0 VAL")
 }
 
 record(waveform, "$(P)ALLMSGS")

--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -7,6 +7,7 @@ record(waveform, "$(P)TITLE")
     field(INP,  "@asyn(icp,0,0)RUNTITLE")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(waveform, "$(P)TITLE:SP")
@@ -27,6 +28,8 @@ record(stringin, "$(P)_RBNUMBER")
     field(INP,  "@asyn(icp,0,0)RBNUMBER")
     field(SCAN, "I/O Intr")
     field(FLNK, "$(S)ED:RBNUMBER.PROC")
+    info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(stringout, "$(P)_RBNUMBER:SP")
@@ -45,6 +48,7 @@ record(stringin, "$(P)RUNNUMBER")
     field(INP,  "@asyn(icp,0,0)RUNNUMBER")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)IRUNNUMBER")
@@ -66,6 +70,8 @@ record(waveform, "$(P)_USERNAME")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn(icp,0,0)USERNAME")
     field(SCAN, "I/O Intr")
+    info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(waveform, "$(P)_USERNAME:SP")
@@ -96,6 +102,7 @@ record(stringin, "$(P)STARTTIME")
     field(INP,  "@asyn(icp,0,0)STARTTIME")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)NPRATIO")
@@ -115,6 +122,7 @@ record(stringin, "$(P)DAETIMINGSOURCE")
     field(INP,  "@asyn(icp,0,0)DAETIMINGSOURCE")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(stringin, "$(P)PERIODTYPE")
@@ -143,6 +151,7 @@ record(longin, "$(P)RAWFRAMES")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)RAWFRAMES_PD")
@@ -151,6 +160,7 @@ record(longin, "$(P)RAWFRAMES_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)RAWFRAMESPD")
     field(SCAN, "I/O Intr")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)GOODFRAMES")
@@ -161,6 +171,7 @@ record(longin, "$(P)GOODFRAMES")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)GOODFRAMES_PD")
@@ -169,6 +180,7 @@ record(longin, "$(P)GOODFRAMES_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)GOODFRAMESPD")
     field(SCAN, "I/O Intr")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)RUNDURATION")
@@ -179,6 +191,7 @@ record(longin, "$(P)RUNDURATION")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "s")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)RUNDURATION_PD")
@@ -187,6 +200,7 @@ record(longin, "$(P)RUNDURATION_PD")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)RUNDURATIONPD")
     field(SCAN, "I/O Intr")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)NUMTIMECHANNELS")
@@ -197,6 +211,7 @@ record(longin, "$(P)NUMTIMECHANNELS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)DAEMEMORYUSED")
@@ -207,6 +222,7 @@ record(longin, "$(P)DAEMEMORYUSED")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "byte")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)NUMSPECTRA")
@@ -217,6 +233,7 @@ record(longin, "$(P)NUMSPECTRA")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")	
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)MONITORCOUNTS")
@@ -227,6 +244,7 @@ record(longin, "$(P)MONITORCOUNTS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "count")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)MONITORSPECTRUM")
@@ -237,6 +255,7 @@ record(longin, "$(P)MONITORSPECTRUM")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
+    info(archive, "VAL")
 }
 
 record(longin, "$(P)PERIODSEQ")
@@ -247,6 +266,7 @@ record(longin, "$(P)PERIODSEQ")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)BEAMCURRENT")
@@ -258,6 +278,7 @@ record(ai, "$(P)BEAMCURRENT")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "uA")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)TOTALUAMPS")
@@ -269,6 +290,7 @@ record(ai, "$(P)TOTALUAMPS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "uA hour")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)TOTALDAECOUNTS")
@@ -290,6 +312,7 @@ record(ai, "$(P)MONITORTO")
     field(PREC, "3")
     field(SCAN, "I/O Intr")
 	field(EGU, "us")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)MONITORFROM")
@@ -300,6 +323,7 @@ record(ai, "$(P)MONITORFROM")
     field(PREC, "3")
     field(SCAN, "I/O Intr")
 	field(EGU, "us")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)COUNTRATE")
@@ -311,6 +335,7 @@ record(ai, "$(P)COUNTRATE")
     field(SCAN, "I/O Intr")
 	field(EGU, "")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(ai, "$(P)EVENTMODEFRACTION")
@@ -576,6 +601,7 @@ record(longin, "$(P)TOTALCOUNTS")
     field(SCAN, "I/O Intr")
     info(INTEREST, "HIGH")
 	field(EGU, "count")
+    info(archive, "VAL")
 }
 
 record(waveform, "$(P)DAESETTINGS")

--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -27,7 +27,6 @@ record(stringin, "$(P)_RBNUMBER")
     field(INP,  "@asyn(icp,0,0)RBNUMBER")
     field(SCAN, "I/O Intr")
     field(FLNK, "$(S)ED:RBNUMBER.PROC")
-    info(INTEREST, "HIGH")
 }
 
 record(stringout, "$(P)_RBNUMBER:SP")
@@ -48,6 +47,17 @@ record(stringin, "$(P)RUNNUMBER")
     info(INTEREST, "HIGH")
 }
 
+record(longin, "$(P)IRUNNUMBER")
+{
+    field(DESC, "Run Number")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)IRUNNUMBER")
+    field(SCAN, "I/O Intr")
+    info(INTEREST, "MEDIUM")
+	info(archive, "VAL")
+	field(EGU, "")
+}
+
 record(waveform, "$(P)_USERNAME")
 {
     field(DESC, "Experiment User name")
@@ -56,7 +66,6 @@ record(waveform, "$(P)_USERNAME")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn(icp,0,0)USERNAME")
     field(SCAN, "I/O Intr")
-    info(INTEREST, "HIGH")
 }
 
 record(waveform, "$(P)_USERNAME:SP")

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -627,6 +627,7 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
     createParam(P_ErrMsgsString, asynParamOctet, &P_ErrMsgs);
     createParam(P_RBNumberString, asynParamOctet, &P_RBNumber);
     createParam(P_RunNumberString, asynParamOctet, &P_RunNumber);
+    createParam(P_IRunNumberString, asynParamInt32, &P_IRunNumber);
     createParam(P_UserNameString, asynParamOctet, &P_UserName);
     createParam(P_InstNameString, asynParamOctet, &P_InstName);
     createParam(P_UserTelephoneString, asynParamOctet, &P_UserTelephone);
@@ -853,7 +854,9 @@ void isisdaeDriver::pollerThread2()
         last_gf = this_gf;
         setStringParam(P_RunTitle, values["RunTitle"]); 
         setStringParam(P_RBNumber, values["RBNumber"]); 
-        setStringParam(P_RunNumber, values["RunNumber"]);
+		const char* rn = values["RunNumber"];
+        setStringParam(P_RunNumber, rn);
+        setIntegerParam(P_IRunNumber, atol(rn));
         setStringParam(P_InstName, values["InstName"]);
         setStringParam(P_UserName, values["UserName"]);
         setStringParam(P_UserTelephone, values["UserTelephone"]);

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -51,6 +51,7 @@ private:
     int P_UserName; //char*
     int P_InstName; //char*
     int P_RunNumber; //char*
+    int P_IRunNumber; //int
     int P_UserTelephone; //char*
     int P_StartTime; //char*
     int P_NPRatio; //double
@@ -136,6 +137,7 @@ private:
 #define P_UserNameString	"USERNAME"
 #define P_InstNameString	"INSTNAME"
 #define P_RunNumberString	"RUNNUMBER"
+#define P_IRunNumberString	"IRUNNUMBER"
 #define P_UserTelephoneString	"USERTELEPHONE"
 #define P_StartTimeString	"STARTTIME"
 #define P_NPRatioString	"NPRATIO"


### PR DESCRIPTION
Relates to https://github.com/ISISComputingGroup/IBEX/issues/1370

To test:
Make this submodule
Make the iocs
Run build_ioc_startups.py (root of EPICS)
Start your instrument
Go to http://localhost:4812/group?name=INST, and look for the records that have had archive values added in this ticket, e.g. RUNNUMBER, TOTALUAMPS, TITLE, _RBNUMBER