### PR TITLE
Do not force read on already monitored PV

### DIFF
--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -317,7 +317,7 @@ caStatus exPV::write ( const casCtx &, const gdd & valueIn )
 //
 caStatus exPV::read ( const casCtx &, gdd & protoIn )
 {
-	if ( (this->interest == false) || !(this->scanOn && this->getScanPeriod() > 0.0) )
+	if (!(this->interest && this->scanOn && this->getScanPeriod() > 0.0))
 	{
 	    this->scan(); // force an update of the value if not monitoring actively
 	}

--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -317,7 +317,10 @@ caStatus exPV::write ( const casCtx &, const gdd & valueIn )
 //
 caStatus exPV::read ( const casCtx &, gdd & protoIn )
 {
-	this->scan(); // force an update of the value
+	if ( (this->interest == false) || !(this->scanOn && this->getScanPeriod() > 0.0) )
+	{
+	    this->scan(); // force an update of the value if not monitoring actively
+	}
     return this->ft.read ( *this, protoIn );
 }
 


### PR DESCRIPTION
To test:
You need to read a DAE value that is updating but not being monitor, so you can have the ibex client running but can't use any value it might display, Assuming it is not displaying any spectra, you can:

start a run
caget a spectrum    IN:DEMO:DAE:SPEC:1:2:C    and check it is increasing each time you read
camonitor a spectrum, check it is increasing
caget a spectrum that is being monitored, check it works



 
, other than that it doesn't break doing a camonitor on  

See ISISComputingGroup/IBEX#1681