### PR TITLE
Initial run diagnostics implementation

### DIFF
--- a/iocBoot/iocisisdaeTest/st.cmd
+++ b/iocBoot/iocisisdaeTest/st.cmd
@@ -5,6 +5,17 @@
 
 < envPaths
 
+epicsEnvSet "WIRING_DIR" "$(ICPCONFIGROOT)/tables"
+epicsEnvSet "WIRING_PATTERN" ".*wiring.*"
+epicsEnvSet "DETECTOR_DIR" "$(ICPCONFIGROOT)/tables"
+epicsEnvSet "DETECTOR_PATTERN" ".*det.*"
+epicsEnvSet "SPECTRA_DIR" "$(ICPCONFIGROOT)/tables"
+epicsEnvSet "SPECTRA_PATTERN" ".*spec.*"
+epicsEnvSet "PERIOD_DIR" "$(ICPCONFIGROOT)/tables"
+epicsEnvSet "PERIOD_PATTERN" ".*period.*"
+epicsEnvSet "TCB_DIR" "$(ICPCONFIGROOT)/tcb"
+epicsEnvSet "TCB_PATTERN" ".*tcb.*"
+
 cd ${TOP}
 
 ## Register all support components
@@ -14,18 +25,29 @@ isisdaeTest_registerRecordDeviceDriver pdbbase
 ##ISIS## Run IOC initialisation 
 < $(IOCSTARTUP)/init.cmd
 
+## used for restarting EPICS archiver via web URL
+webgetConfigure("web")
+
 ## local dae, no dcom/labview
-isisdaeConfigure("icp")
+isisdaeConfigure("icp", 1)
 ## pass 1 as second arg to signify DCOM to either local or remote dae
 #isisdaeConfigure("icp", 1, "localhost")
 #isisdaeConfigure("icp", 1, "ndxchipir", "spudulike", "reliablebeam")
+
+## Load the FileLists
+FileListConfigure("WLIST", "$(WIRING_DIR)", "$(WIRING_PATTERN)", 1)
+FileListConfigure("DLIST", "$(DETECTOR_DIR)", "$(DETECTOR_PATTERN)", 1)
+FileListConfigure("SLIST", "$(SPECTRA_DIR)", "$(SPECTRA_PATTERN)", 1)
+FileListConfigure("PLIST", "$(PERIOD_DIR)", "$(PERIOD_PATTERN)", 1)
+FileListConfigure("TLIST", "$(TCB_DIR)", "$(TCB_PATTERN)", 1)
 
 ## Load record instances
 
 ##ISIS## Load common DB records 
 < $(IOCSTARTUP)/dbload.cmd
 
-dbLoadRecords("$(TOP)/db/isisdae.db","P=$(MYPVPREFIX),Q=DAE:")
+dbLoadRecords("$(TOP)/db/isisdae.db","S=$(MYPVPREFIX), P=$(MYPVPREFIX),Q=DAE:, WIRINGLIST=WLIST, DETECTORLIST=DLIST, SPECTRALIST=SLIST, PERIODLIST=PLIST, TCBLIST=TLIST")
+dbLoadRecords("$(TOP)/db/dae_diag.db","P=$(MYPVPREFIX),Q=DAE:")
 
 ##ISIS## Stuff that needs to be done after all records are loaded but before iocInit is called 
 < $(IOCSTARTUP)/preiocinit.cmd
@@ -38,5 +60,3 @@ iocInit
 
 ##ISIS## Stuff that needs to be done after iocInit is called e.g. sequence programs 
 < $(IOCSTARTUP)/postiocinit.cmd
-
-

--- a/isisdaeApp/Db/Makefile
+++ b/isisdaeApp/Db/Makefile
@@ -11,6 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
 DB += isisdae.db
+DB += dae_diag.db
 DB += dae3_parallel.db
 
 #----------------------------------------------------

--- a/isisdaeApp/Db/dae_diag.db
+++ b/isisdaeApp/Db/dae_diag.db
@@ -91,11 +91,40 @@ record(longin, "$(P)$(Q)DIAG:FRAMES")
     field(SCAN, "I/O Intr")
 }
 
+record(ao, "$(P)$(Q)DIAG:SPEC:INTLOW:SP")
+{
+    field(DESC, "Lower integral limit")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn(icp,0,0)DIAG_SPEC_INTLOW")
+	field(VAL, 0)
+	field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
+record(ao, "$(P)$(Q)DIAG:SPEC:INTHIGH:SP")
+{
+    field(DESC, "Upper integral limit")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn(icp,0,0)DIAG_SPEC_INTHIGH")
+	field(VAL, 0)
+	field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
 record(longin, "$(P)$(Q)DIAG:SUM")
 {
     field(DESC, "Sum of diag spectra counts")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn(icp,0,0)DIAG_SUM")
+    field(SCAN, "I/O Intr")
+}
+
+## number of spectra that matched criteria, which may be more than can be returned in a waveform below
+record(longin, "$(P)$(Q)DIAG:SPEC:MATCH")
+{
+    field(DESC, "Number that matched criteria")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)DIAG_SPEC_MATCH")
     field(SCAN, "I/O Intr")
 }
 

--- a/isisdaeApp/Db/dae_diag.db
+++ b/isisdaeApp/Db/dae_diag.db
@@ -1,0 +1,141 @@
+
+## enable or diable diag
+record(bo, "$(P)$(Q)DIAG:ENABLE:SP")
+{
+    field(DESC, "Enable diag")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_ENABLE")
+	field(VAL, 0)
+	field(ZNAM, "NO")
+	field(ONAM, "YES")
+	field(PINI, "YES")
+    # always disable on IOC startup, don't autosave value
+}
+
+## is diag enabled?
+record(bi, "$(P)$(Q)DIAG:ENABLED")
+{
+    field(DESC, "Diag enabled")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)DIAG_ENABLE")
+	field(ZNAM, "NO")
+	field(ONAM, "YES")
+    field(SCAN, "I/O Intr")
+}
+
+## period number used for diag spectra
+record(longout, "$(P)$(Q)DIAG:PERIOD:SP")
+{
+    field(DESC, "Diag Period")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_PERIOD")
+	field(PINI, "YES")
+	field(VAL, 1)
+    info(autosaveFields, "VAL")
+}
+
+## starting spectrum number for diag
+record(longout, "$(P)$(Q)DIAG:SPEC:START:SP")
+{
+    field(DESC, "Diag Spec Start")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_SPEC_START")
+	field(VAL, 1)
+	field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
+## number of spectra for diag
+record(longout, "$(P)$(Q)DIAG:SPEC:NUM:SP")
+{
+    field(DESC, "Diag Num Spec")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_SPEC_NUM")
+	field(VAL, 10)
+	field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
+## select which spectra to show
+record(mbbo, "$(P)$(Q)DIAG:SPEC:SHOW:SP")
+{
+    field(DESC, "Diag Specs To Show")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_SPEC_SHOW")
+	field(ZRST, "All")
+	field(ZRVL, 0)
+	field(ONST, "Zero Counts Only")
+	field(ONVL, 1)
+	field(TWST, "Non-zero counts only")
+	field(TWVL, 2)
+	field(VAL, 0)
+	field(PINI, "YES")
+    # don't autosave, default to "All" on startup
+}
+
+record(longout, "$(P)$(Q)DIAG:FRAMES:SP")
+{
+    field(DESC, "Min Num Frames for diag")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn(icp,0,0)DIAG_MIN_FRAMES")
+	field(VAL, 0)
+	field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "$(P)$(Q)DIAG:FRAMES")
+{
+    field(DESC, "Num Frames used for diag")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)DIAG_FRAMES")
+    field(SCAN, "I/O Intr")
+}
+
+record(longin, "$(P)$(Q)DIAG:SUM")
+{
+    field(DESC, "Sum of diag spectra counts")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)DIAG_SUM")
+    field(SCAN, "I/O Intr")
+}
+
+record(waveform, "$(P)$(Q)DIAG:TABLE:SPEC")
+{
+    field(DESC, "Spectrum Numbers")
+    field(NELM, "256")
+    field(FTVL, "LONG")
+    field(DTYP, "asynInt32ArrayIn")
+    field(INP,  "@asyn(icp,0,0)DIAG_TABLE_SPEC")
+    field(SCAN, "I/O Intr")
+}
+
+record(waveform, "$(P)$(Q)DIAG:TABLE:SUM")
+{
+    field(DESC, "Spec Integrals")
+    field(NELM, "256")
+    field(FTVL, "LONG")
+    field(DTYP, "asynInt32ArrayIn")
+    field(INP,  "@asyn(icp,0,0)DIAG_TABLE_SUM")
+    field(SCAN, "I/O Intr")
+}
+
+record(waveform, "$(P)$(Q)DIAG:TABLE:MAX")
+{
+    field(DESC, "Max Spec Bin Count")
+    field(NELM, "256")
+    field(FTVL, "LONG")
+    field(DTYP, "asynInt32ArrayIn")
+    field(INP,  "@asyn(icp,0,0)DIAG_TABLE_MAX")
+    field(SCAN, "I/O Intr")
+}
+
+record(waveform, "$(P)$(Q)DIAG:TABLE:CNTRATE")
+{
+    field(DESC, "Count Rate")
+	field(EGU, "Count / Frame")
+    field(NELM, "256")
+    field(FTVL, "DOUBLE")
+    field(DTYP, "asynFloat64ArrayIn")
+    field(INP,  "@asyn(icp,0,0)DIAG_TABLE_CNTRATE")
+    field(SCAN, "I/O Intr")
+}

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -184,7 +184,7 @@ asynStatus isisdaeDriver::writeValue(asynUser *pasynUser, const char* functionNa
 		{
 		    beginStateTransition(RS_BEGINNING);
             zeroRunCounters();
-			m_iface->beginRunEx(value, -1);
+			m_iface->beginRunEx(static_cast<long>(value), -1);
 		}
 		else if (function == P_AbortRun)
 		{
@@ -235,11 +235,11 @@ asynStatus isisdaeDriver::writeValue(asynUser *pasynUser, const char* functionNa
 		}
         else if (function == P_Period)
 		{
-			m_iface->setPeriod(value);
+			m_iface->setPeriod(static_cast<long>(value));
 		}
         else if (function == P_NumPeriods)
 		{
-			m_iface->setNumPeriods(value);
+			m_iface->setNumPeriods(static_cast<long>(value));
 		}
 		endStateTransition();
         asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
@@ -521,7 +521,7 @@ asynStatus isisdaeDriver::writeOctet(asynUser *pasynUser, const char *value, siz
 		    std::string tcb_xml;
 		    if (uncompressString(value_s, tcb_xml) == 0)
 			{
-                unsigned found = tcb_xml.find_last_of(">");  // in cased junk on end
+                size_t found = tcb_xml.find_last_of(">");  // in cased junk on end
                 m_iface->setTCBSettingsXML(tcb_xml.substr(0,found+1));
 			}
 		}        

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -696,6 +696,9 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
     createParam(P_diagSpecNumString, asynParamInt32, &P_diagSpecNum);
     createParam(P_diagSpecShowString, asynParamInt32, &P_diagSpecShow);
     createParam(P_diagSumString, asynParamInt32, &P_diagSum);
+    createParam(P_diagSpecMatchString, asynParamInt32, &P_diagSpecMatch);
+    createParam(P_diagSpecIntLowString, asynParamFloat64, &P_diagSpecIntLow);
+    createParam(P_diagSpecIntHighString, asynParamFloat64, &P_diagSpecIntHigh);
 	
     setIntegerParam(P_StateTrans, 0);
 
@@ -1004,7 +1007,10 @@ void isisdaeDriver::pollerThread3()
 		getIntegerParam(P_diagSpecShow, &spec_type);
 		getIntegerParam(P_diagSpecStart, &first_spec);
 		getIntegerParam(P_diagSpecNum, &num_spec);
-		getIntegerParam(P_diagPeriod, &period);		
+		getIntegerParam(P_diagPeriod, &period);
+		getDoubleParam(P_diagSpecIntLow, &time_low);
+		getDoubleParam(P_diagSpecIntHigh, &time_high);
+		
         unlock(); // getSepctraSum may take a while so release asyn lock
 		m_iface->getSpectraSum(period, first_spec, num_spec, spec_type, 
 		     time_low, time_high, sums[i1], max_vals, spec_nums);
@@ -1029,6 +1035,7 @@ void isisdaeDriver::pollerThread3()
 		doCallbacksFloat64Array(reinterpret_cast<epicsFloat64*>(&(rate[0])), n1, P_diagTableCntRate, 0);
 		setIntegerParam(P_diagFrames, fdiff);
 		setIntegerParam(P_diagSum, sum);
+		setIntegerParam(P_diagSpecMatch, n1);
         callParamCallbacks();
 		b = !b;
     }

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <iomanip>
 #include <sys/timeb.h>
+#include <numeric>
 #include <boost/algorithm/string.hpp>
 
 #include <epicsTypes.h>
@@ -561,9 +562,11 @@ asynStatus isisdaeDriver::writeOctet(asynUser *pasynUser, const char *value, siz
 /// \param[in] dcomint DCOM interface pointer created by lvDCOMConfigure()
 /// \param[in] portName @copydoc initArg0
 isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName) 
-   : asynPortDriver(portName, 
+   : ADDriver(portName, 
                     0, /* maxAddr */ 
                     NUM_ISISDAE_PARAMS,
+					0, // maxBuffers
+					0, // maxMemory
                     asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynFloat64ArrayMask | asynOctetMask | asynDrvUserMask, /* Interface mask */
                     asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynFloat64ArrayMask | asynOctetMask,  /* Interrupt mask */
                     ASYN_CANBLOCK, /* asynFlags.  This driver can block but it is not multi-device */
@@ -571,8 +574,8 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
                     0, /* Default priority */
                     0),	/* Default stack size*/
 					m_iface(iface), m_RunStatus(0), m_vetopc(0.0), m_inStateTrans(false)
-{
-    int i;
+{					
+	int i;
     const char *functionName = "isisdaeDriver";
 //	epicsThreadOnce(&onceId, initCOM, NULL);
 
@@ -681,6 +684,19 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
     createParam(P_tcbFileString, asynParamOctet, &P_tcbFile);
     createParam(P_periodsFileString, asynParamOctet, &P_periodsFile);
 	
+    createParam(P_diagTableSumString, asynParamInt32Array, &P_diagTableSum);
+    createParam(P_diagTableSpecString, asynParamInt32Array, &P_diagTableSpec);
+    createParam(P_diagTableMaxString, asynParamInt32Array, &P_diagTableMax);
+    createParam(P_diagTableCntRateString, asynParamFloat64Array, &P_diagTableCntRate);
+    createParam(P_diagFramesString, asynParamInt32, &P_diagFrames);
+    createParam(P_diagMinFramesString, asynParamInt32, &P_diagMinFrames);
+    createParam(P_diagEnableString, asynParamInt32, &P_diagEnable);
+    createParam(P_diagPeriodString, asynParamInt32, &P_diagPeriod);
+    createParam(P_diagSpecStartString, asynParamInt32, &P_diagSpecStart);
+    createParam(P_diagSpecNumString, asynParamInt32, &P_diagSpecNum);
+    createParam(P_diagSpecShowString, asynParamInt32, &P_diagSpecShow);
+    createParam(P_diagSumString, asynParamInt32, &P_diagSum);
+	
     setIntegerParam(P_StateTrans, 0);
 
     // Create the thread for background tasks (not used at present, could be used for I/O intr scanning) 
@@ -696,6 +712,14 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
                           epicsThreadPriorityMedium,
                           epicsThreadGetStackSize(epicsThreadStackMedium),
                           (EPICSTHREADFUNC)pollerThreadC2, this) == 0)
+    {
+        printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
+        return;
+    }
+    if (epicsThreadCreate("isisdaePoller3",
+                          epicsThreadPriorityMedium,
+                          epicsThreadGetStackSize(epicsThreadStackMedium),
+                          (EPICSTHREADFUNC)pollerThreadC3, this) == 0)
     {
         printf("%s:%s: epicsThreadCreate failure\n", driverName, functionName);
         return;
@@ -719,6 +743,16 @@ void isisdaeDriver::pollerThreadC2(void* arg)
 	if (driver != NULL)
 	{
 	    driver->pollerThread2();
+	}
+}
+
+void isisdaeDriver::pollerThreadC3(void* arg)
+{ 
+	epicsThreadSleep(1.0);	// let constructor complete
+    isisdaeDriver* driver = (isisdaeDriver*)arg; 
+	if (driver != NULL)
+	{
+	    driver->pollerThread3();
 	}
 }
 
@@ -940,6 +974,66 @@ void isisdaeDriver::pollerThread2()
 	}
 }	
 			
+void isisdaeDriver::pollerThread3()
+{
+    static const char* functionName = "isisdaePoller3";
+    double delay = 2.0;
+	std::vector<long> sums[2], max_vals, spec_nums;
+	std::vector<double> rate;
+	int frames[2] = {0, 0}, period = 1, first_spec = 1, num_spec = 10, spec_type = 0;
+	double time_low = 0.0, time_high = -1.0;
+	bool b = true;
+	int i1, i2, n1, sum, fdiff, fdiff_min = 0, diag_enable = 0;
+    lock();
+	// read sums alternately into sums[0] and sums[1] by toggling b so a count rate can be calculated
+	while(true)
+	{
+        unlock();
+		epicsThreadSleep(delay);
+		i1 = (b == true ? 0 : 1);
+		i2 = (b == true ? 1 : 0);
+		frames[i1] = m_iface->getGoodFrames(); // read prior to lock in case ICP busy
+        lock();
+		getIntegerParam(P_diagEnable, &diag_enable);
+		if (diag_enable != 1)
+			continue;
+		fdiff = frames[i1] - frames[i2];
+		getIntegerParam(P_diagMinFrames, &fdiff_min);
+		if (fdiff < fdiff_min)
+			continue;
+		getIntegerParam(P_diagSpecShow, &spec_type);
+		getIntegerParam(P_diagSpecStart, &first_spec);
+		getIntegerParam(P_diagSpecNum, &num_spec);
+		getIntegerParam(P_diagPeriod, &period);		
+        unlock(); // getSepctraSum may take a while so release asyn lock
+		m_iface->getSpectraSum(period, first_spec, num_spec, spec_type, 
+		     time_low, time_high, sums[i1], max_vals, spec_nums);
+        lock();
+		n1 = sums[i1].size();
+		sum = std::accumulate(sums[i1].begin(), sums[i1].end(), 0);
+		rate.resize(n1);
+		if ( n1 == sums[i2].size() && fdiff > 0 )
+		{
+			for(int i=0; i<n1; ++i)
+			{
+				rate[i] = static_cast<double>(sums[i1][i] - sums[i2][i]) / static_cast<double>(fdiff);
+			}
+		}
+		else
+		{
+			std::fill(rate.begin(), rate.end(), 0.0);
+		}
+	    doCallbacksInt32Array(reinterpret_cast<epicsInt32*>(&(sums[i1][0])), n1, P_diagTableSum, 0);
+	    doCallbacksInt32Array(reinterpret_cast<epicsInt32*>(&(max_vals[0])), n1, P_diagTableMax, 0);
+	    doCallbacksInt32Array(reinterpret_cast<epicsInt32*>(&(spec_nums[0])), n1, P_diagTableSpec, 0);
+		doCallbacksFloat64Array(reinterpret_cast<epicsFloat64*>(&(rate[0])), n1, P_diagTableCntRate, 0);
+		setIntegerParam(P_diagFrames, fdiff);
+		setIntegerParam(P_diagSum, sum);
+        callParamCallbacks();
+		b = !b;
+    }
+}
+
 void isisdaeDriver::getDAEXML(const std::string& xmlstr, const std::string& path, std::string& value)
 {
 	value = "";

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -106,6 +106,10 @@ private:
 	int P_diagSpecStart; // int		
 	int P_diagSpecNum; // int		
 	int P_diagSpecShow; // int	
+	int P_diagSpecMatch; // int			
+    int P_diagSpecIntLow; //float				
+    int P_diagSpecIntHigh; // float				
+
 	int P_diagSum; // int				
 	
     int P_AllMsgs; // char
@@ -214,6 +218,9 @@ private:
 #define P_diagSpecNumString			"DIAG_SPEC_NUM"
 #define P_diagSpecShowString		"DIAG_SPEC_SHOW"
 #define P_diagSumString				"DIAG_SUM"
+#define P_diagSpecMatchString				"DIAG_SPEC_MATCH"
+#define P_diagSpecIntLowString				"DIAG_SPEC_INTLOW"
+#define P_diagSpecIntHighString				"DIAG_SPEC_INTHIGH"
 
 #define P_AllMsgsString	"ALLMSGS"
 #define P_ErrMsgsString	"ERRMSGS"

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -1,16 +1,17 @@
 #ifndef ISISDAEDRIVER_H
 #define ISISDAEDRIVER_H
  
-#include "asynPortDriver.h"
+#include "ADDriver.h"
 
 class isisdaeInterface;
 
-class isisdaeDriver : public asynPortDriver 
+class isisdaeDriver : public ADDriver 
 {
 public:
     isisdaeDriver(isisdaeInterface* iface, const char *portName);
  	static void pollerThreadC1(void* arg);
  	static void pollerThreadC2(void* arg);
+ 	static void pollerThreadC3(void* arg);
     enum { RS_PROCESSING=0,RS_SETUP=1,RS_RUNNING=2,RS_PAUSED=3,RS_WAITING=4,RS_VETOING=5,RS_ENDING=6,RS_SAVING=7,
 	        RS_RESUMING=8,RS_PAUSING=9,RS_BEGINNING=10,RS_ABORTING=11,RS_UPDATING=12,RS_STORING=13 };
                 
@@ -93,6 +94,20 @@ private:
 	int P_spectraTableFile; // string
 	int P_tcbFile; // string
 	int P_periodsFile; // string
+	
+	int P_diagTableSum; // int array
+	int P_diagTableMax; // int array
+	int P_diagTableSpec; // int array
+	int P_diagTableCntRate; // float array
+	int P_diagFrames; // int
+	int P_diagMinFrames; // int
+	int P_diagEnable;  // int 
+	int P_diagPeriod; // int			
+	int P_diagSpecStart; // int		
+	int P_diagSpecNum; // int		
+	int P_diagSpecShow; // int	
+	int P_diagSum; // int				
+	
     int P_AllMsgs; // char
     int P_ErrMsgs; // char
 	#define FIRST_ISISDAE_PARAM P_GoodUAH
@@ -106,6 +121,7 @@ private:
 	
 	void pollerThread1();
 	void pollerThread2();
+	void pollerThread3();
     void zeroRunCounters();	
     void updateRunStatus();
 	void reportErrors(const char* exc_text);
@@ -185,6 +201,20 @@ private:
 #define P_spectraTableFileString "SPECFILE"
 #define P_tcbFileString           "TCBFILE"
 #define P_periodsFileString      "PERIODSFILE"
+
+#define P_diagTableSumString		"DIAG_TABLE_SUM"
+#define P_diagTableMaxString		"DIAG_TABLE_MAX"
+#define P_diagTableCntRateString	"DIAG_TABLE_CNTRATE"
+#define P_diagTableSpecString		"DIAG_TABLE_SPEC"
+#define P_diagFramesString			"DIAG_FRAMES"
+#define P_diagMinFramesString		"DIAG_MIN_FRAMES"
+#define P_diagEnableString			"DIAG_ENABLE"
+#define P_diagPeriodString			"DIAG_PERIOD"
+#define P_diagSpecStartString		"DIAG_SPEC_START"
+#define P_diagSpecNumString			"DIAG_SPEC_NUM"
+#define P_diagSpecShowString		"DIAG_SPEC_SHOW"
+#define P_diagSumString				"DIAG_SUM"
+
 #define P_AllMsgsString	"ALLMSGS"
 #define P_ErrMsgsString	"ERRMSGS"
 

--- a/isisdaeApp/src/isisdaeInclude.dbd
+++ b/isisdaeApp/src/isisdaeInclude.dbd
@@ -12,4 +12,3 @@ include "NDPluginSupport.dbd"
 include "ADnEDSupport.dbd"
 include "ffmpegServer.dbd"
 registrar("isisdaeRegister")
-registrar("isisdaeADRegister")

--- a/isisdaeApp/src/isisdaeInterface.cpp
+++ b/isisdaeApp/src/isisdaeInterface.cpp
@@ -221,7 +221,7 @@ void isisdaeInterface::stripTimeStamp(const std::string& in, std::string& out)
 	memcpy(&tmstr, localtime(&now), sizeof(tmstr));
     strftime(time_str, sizeof(time_str), "%Y-%m-", &tmstr);
     out = in;
-	int pos = 0;
+	size_t pos = 0;
 	while( (pos = out.find(time_str, pos)) != std::string::npos )
 	{
 	    out.erase(pos, 20);
@@ -458,7 +458,7 @@ int isisdaeInterface::snapshotCRPT(const std::string& filename, long do_update, 
 	}
 	else
 	{
-	    return callI<int>(boost::bind(&ISISICPINT::snapshotCRPT, boost::cref(filename), do_update, do_pause, _1));
+	    return callI<int>(boost::bind(&ISISICPINT::snapshotCRPT, boost::cref(filename), (do_update != 0 ? true : false), (do_pause != 0 ? true : false), _1));
 	}
 }
 
@@ -490,7 +490,7 @@ std::string isisdaeInterface::getValue(const std::string& name)
 	{
         _bstr_t bs(CComBSTR(name.c_str()).Detach());
 		BSTR res = callD<_bstr_t>(boost::bind(&ICPDCOM::getValue, _1, bs, _2));
-		return COLE2CT(res);
+		return std::string(COLE2CT(res));
 	}
 	else
 	{
@@ -595,12 +595,27 @@ unsigned long isisdaeInterface::getHistogramMemory()
 	return sum;
 }
 
+// needed for VS2010 and std::tr1::bind, VS2015 was OK without
+struct getSpectraSumWrapStruct
+{
+    long period;
+	long first_spec;
+	long num_spec;
+	getSpectraSumWrapStruct(long period_, long first_spec_, long num_spec_) : period(period_), first_spec(first_spec_), num_spec(num_spec_) { }
+};
+
+static HRESULT getSpectraSumWrap(isisdaeInterface::ICPDCOM* icp, const getSpectraSumWrapStruct& w, long spec_type, double time_low, double time_high, VARIANT * sums, VARIANT * max_vals, VARIANT * spec_nums, BSTR * messages)
+{
+    return icp->getSpectraSum(w.period, w.first_spec, w.num_spec, spec_type, time_low, time_high, sums, max_vals, spec_nums, messages);
+}
+
 int isisdaeInterface::getSpectraSum(long period, long first_spec, long num_spec, long spec_type, double time_low, double time_high, std::vector<long>& sums, std::vector<long>& max_vals, std::vector<long>& spec_nums)
 {
 	if (m_dcom)
 	{
 		variant_t sums_v, max_vals_v, spec_nums_v;
-		callDtr1<int>(std::tr1::bind(&ICPDCOM::getSpectraSum, std::tr1::placeholders::_1, period, first_spec, num_spec, spec_type, time_low, time_high, &sums_v, &max_vals_v, &spec_nums_v, std::tr1::placeholders::_2));
+		getSpectraSumWrapStruct w(period, first_spec, num_spec);
+		callDtr1<int>(std::tr1::bind(&getSpectraSumWrap, std::tr1::placeholders::_1, std::tr1::cref(w), spec_type, time_low, time_high, &sums_v, &max_vals_v, &spec_nums_v, std::tr1::placeholders::_2));
 		makeArrayFromVariant(sums, &sums_v);
 		makeArrayFromVariant(max_vals, &max_vals_v);
 		makeArrayFromVariant(spec_nums, &spec_nums_v);
@@ -898,8 +913,8 @@ long isisdaeInterface::getSpectrum(int spec, int period, float* time_channels, f
 		n = arrayVariantLength(&signal_v);
 		for(int i=0; i < std::min(nvals,n); ++i)
 	    {
-	        signal[i] = s[i];
-			time_channels[i] = t[i];
+	        signal[i] = static_cast<float>(s[i]);
+			time_channels[i] = static_cast<float>(t[i]);
 	    }
 		unaccessArrayVariant(&signal_v);
 		unaccessArrayVariant(&time_channels_v);
@@ -908,11 +923,11 @@ long isisdaeInterface::getSpectrum(int spec, int period, float* time_channels, f
 	{
 		std::vector<double> time_channels_v, signal_v;
 		callI<int>(boost::bind(&ISISICPINT::getSpectrum, spec, period, boost::ref(time_channels_v), boost::ref(signal_v), false, true, boost::ref(sum), _1));
-		n = signal_v.size();
+		n = static_cast<long>(signal_v.size());
 		for(int i=0; i < std::min(nvals,n); ++i)
 	    {
-	        time_channels[i] = time_channels_v[i];
-	        signal[i] = signal_v[i];
+	        time_channels[i] = static_cast<float>(time_channels_v[i]);
+	        signal[i] = static_cast<float>(signal_v[i]);
 	    }
 	}
     return n;

--- a/isisdaeApp/src/isisdaeInterface.h
+++ b/isisdaeApp/src/isisdaeInterface.h
@@ -123,6 +123,7 @@ public:
 	int getAsyncMessages(std::list<std::string>& messages);
 	void resetMessages(); 
 	static void stripTimeStamp(const std::string& in, std::string& out);
+	typedef isisicpLib::Idae ICPDCOM;
 	
 private:
 	std::string m_host;
@@ -134,7 +135,6 @@ private:
 	int m_options; ///< the various #lvDCOMOptions currently in use
 	epicsMutex m_lock;
 	bool m_dcom;
-	typedef isisicpLib::Idae ICPDCOM;
 	CComPtr<ICPDCOM> m_icp;
 	COAUTHIDENTITY* m_pidentity;
 

--- a/isisdaeApp/src/isisdaeInterface.h
+++ b/isisdaeApp/src/isisdaeInterface.h
@@ -106,7 +106,7 @@ public:
     double getMEvents();
     unsigned long getTotalCounts();
     unsigned long getHistogramMemory();
-    unsigned long getSpectraSum();
+    int getSpectraSum(long period, long first_spec, long num_spec, long spec_type, double time_low, double time_high,                       std::vector<long>& sums, std::vector<long>& max_vals, std::vector<long>& spec_nums);
     int getRunDataFromDAE(std::map<std::string, DAEValue>& values);
     int getDAESettingsXML(std::string& result);
     int setDAESettingsXML(const std::string& settings);
@@ -151,10 +151,12 @@ private:
 	std::string getValue(const std::string& name);
 	// call ISISICPINT functions
 	template <typename T> T callI( boost::function<T(std::string&)> func );
+	template <typename T> T callItr1( std::tr1::function<T(std::string&)> func );
 
 	// call ICPDCOM functions
 	template <typename T> T callD( boost::function<T(ICPDCOM*, BSTR*)> func );
-		   
+	template <typename T> T callDtr1( std::tr1::function<T(ICPDCOM*, BSTR*)> func );
+  
 	int getXMLSettingsI(std::string& result, const std::string& template_file, int (*func)(const std::string&, std::string&, std::string&));
     int getXMLSettingsD(std::string& result, const std::string& template_file, HRESULT (ICPDCOM::*func)(_bstr_t, BSTR*, BSTR*));
 };

--- a/isisdaeApp/src/variant_utils.cpp
+++ b/isisdaeApp/src/variant_utils.cpp
@@ -167,6 +167,8 @@ int arrayVariantDimensions(VARIANT* v, int dims_array[], int& ndims)
 	return 0;
 }
 
+
+
 template <typename T> 
 int makeVariantFromArray(VARIANT* v, const std::vector<T>& the_array)
 {
@@ -230,6 +232,30 @@ int makeVariantFromArray(VARIANT* v, const char* the_array, int n)
 }
 
 template int makeVariantFromArray(VARIANT* v, const std::vector<float>& the_array);
+
+/// copy a DCOM array variant into a vector
+template <typename T> 
+int makeArrayFromVariant(std::vector<T>& the_array, VARIANT* v)
+{
+	VARTYPE vt_type = CVarTypeInfo<T>::VT;
+	T* v_array = NULL;
+	if (accessArrayVariant(v, &v_array) != 0)
+	{
+		return -1;		
+	}
+	int n = arrayVariantLength(v);
+	the_array.resize(n);
+	for(int i=0; i<n; ++i)
+	{
+		the_array[i] = v_array[i];
+	}
+	unaccessArrayVariant(v);
+	return 0;
+}
+
+template int makeArrayFromVariant(std::vector<float>& the_array, VARIANT *v);
+template int makeArrayFromVariant(std::vector<long>& the_array, VARIANT *v);
+
 
 /// we need to imitate a DCOM array coming from labview, which has column index fastest varying rather than row  
 int stringTableToVariant(const std::vector< std::vector<std::string> >& string_table, VARIANT* v)

--- a/isisdaeApp/src/variant_utils.h
+++ b/isisdaeApp/src/variant_utils.h
@@ -33,6 +33,9 @@ int makeVariantFromArray(VARIANT* v, const T* the_array, int n);
 template <typename T> 
 int makeVariantFromArray(VARIANT* v, const std::vector<T>& the_array);
 
+template <typename T> 
+int makeArrayFromVariant(std::vector<T>& the_array, VARIANT* v);
+
 int stringTableToVariant(const std::vector< std::vector<std::string> >& string_table, VARIANT* v);
 
 #endif /* VARIANT_UTILS_H */

--- a/isisdaeTestApp/src/build.mak
+++ b/isisdaeTestApp/src/build.mak
@@ -27,6 +27,7 @@ $(APPNAME)_DBD += caPutLog.dbd
 ## add other dbd here ##
 $(APPNAME)_DBD += isisdae.dbd
 $(APPNAME)_DBD += webget.dbd
+$(APPNAME)_DBD += FileList.dbd
 
 # Add all the support libraries needed by this IOC
 ## ISIS standard libraries ##
@@ -40,7 +41,7 @@ $(APPNAME)_LIBS += autosave
 $(APPNAME)_LIBS += utilities
 ## Add other libraries here ##
 #$(APPNAME)_LIBS += xxx
-$(APPNAME)_LIBS += isisdae asyn oncrpc zlib pcrecpp pcre pugixml
+$(APPNAME)_LIBS += isisdae FileList asyn oncrpc zlib pcrecpp pcre pugixml
 $(APPNAME)_LIBS += cas gdd 
 $(APPNAME)_LIBS += ffmpegServer
 $(APPNAME)_LIBS += avdevice


### PR DESCRIPTION
This adds a dae_diagnostics.db file containing new PVs to build a diagnostics view from

See ISISComputingGroup/IBEX#1846

You should be able to test by running up the isisdaeTest  IOC though you could also locally modify your  ioc/ISISDAE to load up dae_diagnostics.db as well

Once you write 1 to DIAG:ENABLE:SP arrays of data should appear in the various DIAG:TABLE:* waveforms which match the coloums in the LabVIEW table