### PR TITLE
Ticket1968: Reduce scan rate of unmonitored PVs

### DIFF
--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -550,8 +550,12 @@ inline void exServer::removeAliasName ( pvEntry & entry )
 }
 
 inline double exPV::getScanPeriod ()
-{
-    return this->interest ? this->info.getScanPeriod () : 60.0L;
+{ 
+    double scanPeriod = this->info.getScanPeriod ();
+    if ( ! this->interest ) {
+        scanPeriod *= 100.0L;
+    }
+	return scanPeriod;
 }
 
 inline caStatus exPV::readNoCtx ( smartGDDPointer pProtoIn )

--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -551,11 +551,7 @@ inline void exServer::removeAliasName ( pvEntry & entry )
 
 inline double exPV::getScanPeriod ()
 {
-    double curPeriod = this->info.getScanPeriod ();
-    if ( ! this->interest ) {
-        curPeriod *= 10.0L;
-    }
-    return curPeriod;
+    return this->interest ? this->info.getScanPeriod () : 60.0L;
 }
 
 inline caStatus exPV::readNoCtx ( smartGDDPointer pProtoIn )


### PR DESCRIPTION
### Description of work

Reduce the scan rate of PVs we're not watching. We can end up creating a lot of these from the GUI so keep the scan rate very low so as to limit the performance impact.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1968

### Acceptance criteria

This should have no noticeable affect on the GUI, except that the spectra updates freeze less often.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

