### PR TITLE
Remove sim mode on title for IBEX

### DIFF
--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -622,6 +622,7 @@ record(stringin, "$(P)$(Q)RUNSTATE_STR")
     field(DESC, "Run State (String)")
     field(INP, "$(P)$(Q)RUNSTATE CP")
     info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }
 
 record(bi, "$(P)$(Q)STATETRANS")
@@ -1211,4 +1212,14 @@ record(longout, "$(P)$(Q)_RESTART_ARCHIVER_PS")
 {
     field(OUT, "$(P)CS:PS:ARBLOCK:RESTART PP")
     field(VAL, 1)
+}
+
+## has simulation mode been enabled in ISISICP
+record(bi, "$(P)$(Q)SIM_MODE")
+{
+    field(DTYP, "asynInt32")
+	field(ZNAM, "No")
+	field(ONAM, "Yes")
+    field(INP, "@asyn(icp,0,0)SIM_MODE")
+	field(SCAN, "I/O Intr")
 }

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -758,8 +758,10 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName)
 	createParam(P_integralsEnableString, asynParamInt32, &P_integralsEnable); 
 	createParam(P_integralsSpecStartString, asynParamInt32, &P_integralsSpecStart); 
 	createParam(P_integralsTransformModeString, asynParamInt32, &P_integralsTransformMode); 
+	createParam(P_simulationModeString, asynParamInt32, &P_simulationMode); 
 	
     setIntegerParam(P_StateTrans, 0);
+    setIntegerParam(P_simulationMode, 0);
 
     // area detector defaults
 //	int maxSizeX = 128, maxSizeY = 128;
@@ -993,6 +995,7 @@ void isisdaeDriver::pollerThread2()
     double delay = 2.0;  
     long this_rf = 0, this_gf = 0, last_rf = 0, last_gf = 0;
     bool check_settings;
+	static const std::string sim_mode_title("(DAE SIMULATION MODE) "); // prefix added by ICP if simulation mode enabled in icp_config.xml
     std::string daeSettings;
     std::string tcbSettings, tcbSettingComp;
     std::string hardwarePeriodsSettings;
@@ -1039,7 +1042,20 @@ void isisdaeDriver::pollerThread2()
         }
         last_rf = this_rf;
         last_gf = this_gf;
-        setStringParam(P_RunTitle, values["RunTitle"]); 
+		
+		// strip simulation mode prefix from title and instead set simulation PV
+		std::string title(values["RunTitle"]);
+		if ( !title.compare(0, sim_mode_title.size(), sim_mode_title) )
+		{
+			title.erase(0, sim_mode_title.size());
+            setIntegerParam(P_simulationMode, 1);
+		}
+		else
+		{
+            setIntegerParam(P_simulationMode, 0);			
+		}
+        setStringParam(P_RunTitle, title.c_str());
+		
         setStringParam(P_RBNumber, values["RBNumber"]); 
 		const char* rn = values["RunNumber"];
         setStringParam(P_RunNumber, rn);

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -995,7 +995,7 @@ void isisdaeDriver::pollerThread2()
     double delay = 2.0;  
     long this_rf = 0, this_gf = 0, last_rf = 0, last_gf = 0;
     bool check_settings;
-	static const std::string sim_mode_title("(DAE SIMULATION MODE) "); // prefix added by ICP if simulation mode enabled in icp_config.xml
+	static const std::string sim_mode_title("(DAE SIMULATION MODE)"); // prefix added by ICP if simulation mode enabled in icp_config.xml
     std::string daeSettings;
     std::string tcbSettings, tcbSettingComp;
     std::string hardwarePeriodsSettings;
@@ -1048,6 +1048,11 @@ void isisdaeDriver::pollerThread2()
 		if ( !title.compare(0, sim_mode_title.size(), sim_mode_title) )
 		{
 			title.erase(0, sim_mode_title.size());
+			// ICP adds an extra space after prefix if title non-zero size
+			if (title.size() > 0 && title[0] == ' ')
+			{
+				title.erase(0, 1);
+			}
             setIntegerParam(P_simulationMode, 1);
 		}
 		else

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -115,7 +115,7 @@ private:
     int P_diagSpecIntLow; //float				
     int P_diagSpecIntHigh; // float				
 	int P_diagSum; // int
-	
+	int P_simulationMode; // int
 	// create area detector views of intregrals of spectra in event mode
 	int P_integralsSpecStart; // int
 	int P_integralsTransformMode; // int
@@ -244,6 +244,8 @@ private:
 #define P_integralsSpecStartString				"INTG_SPEC_START"
 #define	P_integralsTransformModeString 			"INTG_TRANS_MODE"
 #define P_integralsEnableString					"INTG_ENABLE"
+
+#define P_simulationModeString					"SIM_MODE"
 
 #define P_AllMsgsString	"ALLMSGS"
 #define P_ErrMsgsString	"ERRMSGS"


### PR DESCRIPTION
This PR removes the "(DAE SIMULATION MODE)" from the title and creates a PV that can be used to detect simulation mode

See ISISComputingGroup/IBEX#628
