### PR TITLE
Enable AsyncIO for reads

### DIFF
--- a/isisdaeApp/src/CountsPV.cpp
+++ b/isisdaeApp/src/CountsPV.cpp
@@ -6,7 +6,7 @@
 #include "gddApps.h"
 #include "isisdaeInterface.h"
 
-CountsPV::CountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int spec, int period ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn), m_spec(spec), m_period(period)
+CountsPV::CountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int spec, int period ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, true), m_spec(spec), m_period(period)
 {
 
 }
@@ -19,11 +19,11 @@ bool CountsPV::getNewValue(smartGDDPointer& pDD)
         cas.iface()->getSpectrumIntegral(m_spec, m_period, 0.0, -1.0, counts);
 	}
 	catch(const std::exception& ex) {
-		std::cerr << "Exception in CountsPV::getNewValue(): " << ex.what() << std::endl;
+		std::cerr << "CAS: Exception in CountsPV::getNewValue(): " << ex.what() << std::endl;
 		return false;
 	}
 	catch(...) {
-		std::cerr << "Exception in CountsPV::getNewValue()" << std::endl;
+		std::cerr << "CAS: Exception in CountsPV::getNewValue()" << std::endl;
 		return false;
 	}
 	if ( this->pValue.valid() && (static_cast<int>(* this->pValue) == counts) )

--- a/isisdaeApp/src/FixedValuePV.cpp
+++ b/isisdaeApp/src/FixedValuePV.cpp
@@ -9,7 +9,7 @@
 /// class for a PV that has a fixed, unchaning value
 
 template <typename T>
-FixedValuePV<T>::FixedValuePV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const T& value ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn), m_value(value), m_first_call(true)
+FixedValuePV<T>::FixedValuePV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const T& value ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, false), m_value(value), m_first_call(true)
 {
 
 }

--- a/isisdaeApp/src/MonLookupPV.cpp
+++ b/isisdaeApp/src/MonLookupPV.cpp
@@ -8,7 +8,7 @@
 
 /// class for a PV that converts a monitor number into a spectrum number
 
-MonLookupPV::MonLookupPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int monitor ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn), m_monitor(monitor)
+MonLookupPV::MonLookupPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int monitor ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, false), m_monitor(monitor)
 {
 
 }

--- a/isisdaeApp/src/NORDPV.cpp
+++ b/isisdaeApp/src/NORDPV.cpp
@@ -9,7 +9,7 @@
 /// class for a PV that returns the current size of an array, this field is called NORD in an EPICS waveform record hence the name of this class.
 /// it is initialised with a reference to the array size to monitor, which is usually from something like a spectrumPV class   
 
-NORDPV::NORDPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int& nord ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn), m_nord(nord)
+NORDPV::NORDPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int& nord ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, false), m_nord(nord)
 {
 
 }

--- a/isisdaeApp/src/SpectrumPV.cc
+++ b/isisdaeApp/src/SpectrumPV.cc
@@ -9,7 +9,7 @@
 /// the #NORDPV class. It thus looks a bit like an EPICS Waveform record and, like waveform, export an NELM field too.   
 
 SpectrumPV::SpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, char axis, int spec, int period )
-	   : exVectorPV(cas, setup, preCreateFlag, scanOnIn), m_axis(axis), m_spec(spec), m_period(period), m_nord(0)
+	   : exVectorPV(cas, setup, preCreateFlag, scanOnIn, true), m_axis(axis), m_spec(spec), m_period(period), m_nord(0)
 {
 
 }
@@ -44,13 +44,13 @@ bool SpectrumPV::getNewValue(smartGDDPointer& pDD)
 	    n = cas.iface()->getSpectrum(m_spec, m_period, pX, pY, nmax);
 	}
 	catch(const std::exception& ex) {
-		std::cerr << "Exception in SpectrumPV::getNewValue(): " << ex.what() << std::endl;
+		std::cerr << "CAS: Exception in SpectrumPV::getNewValue(): " << ex.what() << std::endl;
         delete[] pX;
         delete[] pY;
 		return false;
 	}
 	catch(...) {
-		std::cerr << "Exception in SpectrumPV::getNewValue()" << std::endl;
+		std::cerr << "CAS: Exception in SpectrumPV::getNewValue()" << std::endl;
         delete[] pX;
         delete[] pY;
 		return false;

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -74,7 +74,7 @@ exServer::exServer ( const char * const pvPrefix,
 			m_ntc = 8000;
 		}
 	}
-	std::cerr << "Spectrum array max size set to " << m_ntc << std::endl;
+	std::cerr << "CAS: Spectrum array max size set to " << m_ntc << std::endl;
 	
     exPV::initFT();
 	setDebugLevel(5);
@@ -281,7 +281,12 @@ void exServer::show (unsigned level) const
     //
     this->stringResTbl.show(level);
 
-    //
+	for (std::map<std::string, pvInfo*>::const_iterator it = m_pvList.begin(); it != m_pvList.end(); ++it)
+	{
+		std::cerr << "PV: \"" << it->second->getName() << "\"" << std::endl;
+		it->second->getPV()->show(level);
+	}
+	//
     // print information about ca server libarary
     // internals
     //
@@ -371,7 +376,7 @@ void exServer::createCountsPV(const char* prefix, int spec, int period)
 {
 	char buffer[256], pvAlias[256];
     sprintf(buffer, "%s:%d:%d:C", prefix, period, spec);
-    pvInfo* pPVI = new pvInfo (0.5, buffer, 1.0e9f, 0.0f, "count", aitEnumInt32, 1);
+    pvInfo* pPVI = new pvInfo (0.5, buffer, 1.0e9f, 0.0f, "cnt", aitEnumInt32, 1);
     m_pvList[buffer] = pPVI;
 	exPV* pPV = new CountsPV(*this, *pPVI, true, scanOn, spec, period);
     pPVI->setPV(pPV);
@@ -400,7 +405,7 @@ void exServer::createCountsPV(const char* prefix, int spec, int period)
 	}
 
     sprintf(buffer, "%s:%d:%d:C.EGU", prefix, period, spec);
-	pPVI = createFixedPV(buffer, std::string("count"), "", aitEnumString);
+	pPVI = createFixedPV(buffer, std::string("cnt"), "", aitEnumString);
 	if (period == 1)
 	{
         sprintf(buffer, "%s:%d:C.EGU", prefix, spec);

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -2004,6 +2004,7 @@ static void daeCASThread(void* arg)
     errlogSevPrintf (errlogMajor, "CAS: daeCASThread exiting\n" );
     //pCAS->show(2u);
     delete pCAS;
+	pCAS = NULL;
     errlogFlush ();
 }
 
@@ -2022,7 +2023,14 @@ extern "C" {
 
 void isisdaeShowPCAS(int level)
 {
-	pCAS->show(level);
+	if (pCAS != NULL)
+	{
+	    pCAS->show(level);
+	}
+	else
+	{
+		std::cerr << "CAS: channel access server is not running" << std::endl;
+	}
 }
 
 /// EPICS iocsh callable function to call constructor of lvDCOMInterface().

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -18,9 +18,9 @@ public:
 
     // These are the methods that we override from asynPortDriver
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
-//	virtual asynStatus readInt32(asynUser *pasynUser, epicsInt32 *value);
+	virtual asynStatus readInt32(asynUser *pasynUser, epicsInt32 *value);
     virtual asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
-//  virtual asynStatus readFloat64(asynUser *pasynUser, epicsFloat64 *value);
+    virtual asynStatus readFloat64(asynUser *pasynUser, epicsFloat64 *value);
 	virtual asynStatus readOctet(asynUser *pasynUser, char *value, size_t maxChars, size_t *nActual, int *eomReason);
 	virtual asynStatus writeOctet(asynUser *pasynUser, const char *value, size_t maxChars, size_t *nActual);
     virtual asynStatus readFloat64Array(asynUser *pasynUser, epicsFloat64 *value, size_t nElements, size_t *nIn);


### PR DESCRIPTION
* All error messages now have CAS: prefix so easier to find in logs
* new IOC command isisdaeShowPCAS()   use e.g.    isisdaeShowPCAS 2   at EPICS prompt
* Implemented asyncIO for some reads, in particular spectra
* changed "count" units to "cnt" so fits in dashboard
* Added better implementation of readFloat64() and readInt32() direct reads but not sure if they were ever used (most DBs are on I/O intr)

See ISISComputingGroup/IBEX#3157
