### PR TITLE
always copy needed visa dll into build

### DIFF
--- a/postbuild/update_dlls.bat
+++ b/postbuild/update_dlls.bat
@@ -15,7 +15,5 @@ xcopy /i /q /d /y "%ICPDIR%\release\*.pdb" "%MYDIR%..\bin\windows-x64"
 xcopy /i /q /d /y "%ICPDIR%\crt_manifest_for_dae3\*.*" "%MYDIR%..\bin\windows-x64-debug"
 
 REM need visa64.dll, visaConfMgr.dll and visaUtilities.dll  
-if not exist "c:\windows\system32\visa64.dll" (
-    xcopy /i /q /d /y "%ICPDIR%\visa\*.dll" "%MYDIR%..\bin\windows-x64-debug"
-    xcopy /i /q /d /y "%ICPDIR%\visa\*.dll" "%MYDIR%..\bin\windows-x64"
-)
+xcopy /i /q /d /y "%ICPDIR%\visa\*.dll" "%MYDIR%..\bin\windows-x64-debug"
+xcopy /i /q /d /y "%ICPDIR%\visa\*.dll" "%MYDIR%..\bin\windows-x64"


### PR DESCRIPTION
visa build was needed on squish but wasn't there. Before this it only copied the dll if it didn't exist (this was for devs) now it always does it. It should not interfere because the only reason for needing the dll is if the IOC doesn't use dcom in which case it is not an instrument.