### PR TITLE
Adding required sample and beamline parameters

### DIFF
--- a/isisdaeApp/Db/inst_string_parameters.substitutions
+++ b/isisdaeApp/Db/inst_string_parameters.substitutions
@@ -44,5 +44,8 @@ pattern { P, Q, DESC, CATEGORY, UNITS }
     { "\$(P)", "PARS:SAMPLE:MEAS:TYPE", "Measurement Type", "SAMPLEPAR", "" }
     { "\$(P)", "PARS:SAMPLE:MEAS:SUBID", "Measurement SubID", "SAMPLEPAR", "" }
     { "\$(P)", "PARS:SAMPLE:MEAS:LABEL", "Measurement Label", "SAMPLEPAR", "" }
+    { "\$(P)", "PARS:SAMPLE:TEMP_LABEL", "Temperature Label", "SAMPLEPAR", "" }
+    { "\$(P)", "PARS:SAMPLE:FIELD_LABEL", "Magnetic Field Label", "SAMPLEPAR", "" }
+    { "\$(P)", "PARS:SAMPLE:COMMENTS", "Comments", "SAMPLEPAR", "" }
     { "\$(P)", "PARS:BL:BEAMSTOP:POS", "Beamstop Position", "BEAMLINEPAR", "" }
     { "\$(P)", "PARS:BL:JOURNAL:BLOCKS", "Journal Blocks", "BEAMLINEPAR", "" }

--- a/isisdaeApp/Db/inst_string_parameters.substitutions
+++ b/isisdaeApp/Db/inst_string_parameters.substitutions
@@ -48,4 +48,5 @@ pattern { P, Q, DESC, CATEGORY, UNITS }
     { "\$(P)", "PARS:SAMPLE:FIELD_LABEL", "Magnetic Field Label", "SAMPLEPAR", "" }
     { "\$(P)", "PARS:SAMPLE:COMMENTS", "Comments", "SAMPLEPAR", "" }
     { "\$(P)", "PARS:BL:BEAMSTOP:POS", "Beamstop Position", "BEAMLINEPAR", "" }
-    { "\$(P)", "PARS:BL:JOURNAL:BLOCKS", "Journal Blocks", "BEAMLINEPAR", "" }
+    { "\$(P)", "PARS:BL:GEOMETRY", "Beamstop Position", "BEAMLINEPAR", "" }
+    { "\$(P)", "PARS:BL:JOURNAL:BLOCKS", "Instrument Geometry", "BEAMLINEPAR", "" }


### PR DESCRIPTION
Check sample and beamline parameters are available through: `caget -t -S TE:NDLT1208:CS:BLOCKSERVER:SAMPLE_PARS|uzhex` and `caget -t -S TE:NDLT1208:CS:BLOCKSERVER:BEAMLINE_PARS|uzhex` respectively. Check that errors no longer occur on https://github.com/ISISNeutronMuon/InstrumentScripts/pull/45