### PR TITLE
Async scan

### DIFF
--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -128,6 +128,7 @@ exPV::expire ( const epicsTime & /*currentTime*/ ) // X aCC 361
 		errlogSevPrintf(errlogMajor, "CAS: exPV::expire: Scan failed");
 	}
 	this->timerDone.signal();
+    epicsThreadSleep(.001); // yield thread, this is in case we have a big timer queue and start to starve DAE access
     if ( this->scanOn && this->getScanPeriod() > 0.0 ) {
         return expireStatus ( restart, this->getScanPeriod() );
     }

--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -113,6 +113,7 @@ caStatus exPV::update ( const gdd & valueIn )
 epicsTimerNotify::expireStatus
 exPV::expire ( const epicsTime & /*currentTime*/ ) // X aCC 361
 {
+    static const double sleep_delay = atof(getenv("ISISDAE_TIMER_SLEEP") != NULL ? getenv("ISISDAE_TIMER_SLEEP") : ".001");
 	try 
 	{
         this->scan();
@@ -128,7 +129,7 @@ exPV::expire ( const epicsTime & /*currentTime*/ ) // X aCC 361
 		errlogSevPrintf(errlogMajor, "CAS: exPV::expire: Scan failed");
 	}
 	this->timerDone.signal();
-    epicsThreadSleep(.001); // yield thread, this is in case we have a big timer queue and start to starve DAE access
+    epicsThreadSleep(sleep_delay); // yield thread, this is in case we have a big timer queue and start to starve DAE access
     if ( this->scanOn && this->getScanPeriod() > 0.0 ) {
         return expireStatus ( restart, this->getScanPeriod() );
     }

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -100,7 +100,7 @@ exServer::exServer ( const char * const pvPrefix,
 
     if ( asyncScan ) {
         unsigned timerPriotity;
-        epicsThreadBooleanStatus etbs = epicsThreadLowestPriorityLevelAbove (
+        epicsThreadBooleanStatus etbs = epicsThreadLowestPriorityLevelBelow (
                 epicsThreadGetPrioritySelf (), & timerPriotity );
         if ( etbs != epicsThreadBooleanStatusSuccess ) {
             timerPriotity = epicsThreadGetPrioritySelf ();

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -100,8 +100,17 @@ exServer::exServer ( const char * const pvPrefix,
 
     if ( asyncScan ) {
         unsigned timerPriotity;
-        epicsThreadBooleanStatus etbs = epicsThreadHighestPriorityLevelBelow (
+        int timer_priority = atoi(getenv("ISISDAE_TIMER_PRIORITY") != NULL ?  getenv("ISISDAE_TIMER_PRIORITY") : "1");
+        epicsThreadBooleanStatus etbs = epicsThreadBooleanStatusSuccess;
+        if (timer_priority > 0) {
+            etbs = epicsThreadLowestPriorityLevelAbove (
                 epicsThreadGetPrioritySelf (), & timerPriotity );
+        } else if (timer_priority < 0) {
+            etbs = epicsThreadHighestPriorityLevelBelow (
+                epicsThreadGetPrioritySelf (), & timerPriotity );
+        } else {
+            timerPriotity = epicsThreadGetPrioritySelf ();
+        }
         if ( etbs != epicsThreadBooleanStatusSuccess ) {
             timerPriotity = epicsThreadGetPrioritySelf ();
         }

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -100,7 +100,7 @@ exServer::exServer ( const char * const pvPrefix,
 
     if ( asyncScan ) {
         unsigned timerPriotity;
-        epicsThreadBooleanStatus etbs = epicsThreadLowestPriorityLevelBelow (
+        epicsThreadBooleanStatus etbs = epicsThreadHighestPriorityLevelBelow (
                 epicsThreadGetPrioritySelf (), & timerPriotity );
         if ( etbs != epicsThreadBooleanStatusSuccess ) {
             timerPriotity = epicsThreadGetPrioritySelf ();

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -2367,7 +2367,7 @@ static void daeCASThread(void* arg)
     const char*        pvPrefix;
     unsigned    aliasCount = 1u;
     unsigned    scanOn = true;
-    unsigned    syncScan = true;
+    unsigned    syncScan = false;
     unsigned    maxSimultAsyncIO = 1000u;
 
 	isisdaeDriver::waitForIOCRunning();


### PR DESCRIPTION
Use a lower scan priority timer queue for spectrum reading, may help with merlin issue when DAE transfer speed goes slow?

See ISISComputingGroup/IBEX#6560
