### PR TITLE
Try to stop spectra gettng into alarm or disconnected

### DIFF
--- a/isisdaeApp/src/FixedValuePV.cpp
+++ b/isisdaeApp/src/FixedValuePV.cpp
@@ -39,6 +39,8 @@ bool FixedValuePV<std::string>::getNewValue(smartGDDPointer& pDD)
 	return true;
 }
 
+template class FixedValuePV<char>;
+template class FixedValuePV<aitEnum16>;
 template class FixedValuePV<int>;
 template class FixedValuePV<float>;
 template class FixedValuePV<std::string>;

--- a/isisdaeApp/src/FixedValuePV.cpp
+++ b/isisdaeApp/src/FixedValuePV.cpp
@@ -43,5 +43,6 @@ template class FixedValuePV<char>;
 template class FixedValuePV<aitEnum16>;
 template class FixedValuePV<int>;
 template class FixedValuePV<float>;
+template class FixedValuePV<double>;
 template class FixedValuePV<std::string>;
 

--- a/isisdaeApp/src/Makefile
+++ b/isisdaeApp/src/Makefile
@@ -36,6 +36,7 @@ isisdae_SRCS += SpectrumPV.cc NORDPV.cc MonLookupPV.cc CountsPV.cc FixedValuePV.
 isisdae_SRCS += exChannel.cc exPV.cc exScalarPV.cc exVectorPV.cc exServer.cc
 isisdae_SRCS += isisdaeDriver.cpp isisdaeInterface.cpp CRPTMapping.cpp
 isisdae_SRCS += MonitorSpectrumPV.cpp MonitorCountsPV.cpp dae_isisicpint_dummy.cpp
+isisdae_SRCS += NoAlarmPV.cpp
 
 isisdae_LIBS += webget htmltidy asyn oncrpc utilities zlib pcrecpp pcre pugixml
 isisdae_LIBS += ADnEDSupport

--- a/isisdaeApp/src/MonLookupPV.cpp
+++ b/isisdaeApp/src/MonLookupPV.cpp
@@ -8,7 +8,7 @@
 
 /// class for a PV that converts a monitor number into a spectrum number
 
-MonLookupPV::MonLookupPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int monitor ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, false), m_monitor(monitor)
+MonLookupPV::MonLookupPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int monitor ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, true), m_monitor(monitor)
 {
 
 }

--- a/isisdaeApp/src/NoAlarmPV.cpp
+++ b/isisdaeApp/src/NoAlarmPV.cpp
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+
+#include "exServer.h"
+#include "gddApps.h"
+
+NoAlarmPV::NoAlarmPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn) : FixedValuePV<aitEnum16>(cas, setup, preCreateFlag, scanOnIn, 0)
+{
+    assert(this->info.getType () == aitEnumEnum16);
+}
+
+caStatus NoAlarmPV::getEnumsImpl ( gdd & enumsIn )
+{
+        static const unsigned nStr = 1;
+        aitFixedString *str;
+        exFixedStringDestructor *pDes;
+
+        str = new aitFixedString[nStr];
+        if (!str) {
+            return S_casApp_noMemory;
+        }
+
+        pDes = new exFixedStringDestructor;
+        if (!pDes) {
+            delete [] str;
+            return S_casApp_noMemory;
+        }
+
+        strncpy (str[0].fixed_string, "NO_ALARM", 
+            sizeof(str[0].fixed_string));
+
+        enumsIn.setDimension(1);
+        enumsIn.setBound (0,0,nStr);
+        enumsIn.putRef (str, pDes);
+
+        return S_cas_success;
+}
+

--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -370,6 +370,7 @@ caStatus exPV::read ( const casCtx & ctx, gdd & protoIn )
 	if (m_asyncIO)
 	{
 		myAsyncReadIO *pIO = new myAsyncReadIO(ctx, protoIn, *this);  // will delete itself on IO completion
+        epicsThreadCreate("myAsyncReadIO", epicsThreadPriorityMedium, epicsThreadStackMedium, myAsyncReadIO::readThreadC, pIO);
 		return S_casApp_asyncCompletion;
 	}
 	else

--- a/isisdaeApp/src/exPV.cc
+++ b/isisdaeApp/src/exPV.cc
@@ -102,6 +102,9 @@ exPV::expire ( const epicsTime & /*currentTime*/ ) // X aCC 361
 {
     static const double sleep_delay = atof(getenv("ISISDAE_TIMER_SLEEP") != NULL ? getenv("ISISDAE_TIMER_SLEEP") : ".001");
     // only periodic scan if somebody is interested in us
+    if (isisdaePCASDebug > 0) {
+        std::cerr << "CAS: exPV::expire() timer expired \"" << getName() << "\"" << std::endl;
+    }
     if (this->interest) {
         doScan();
     }
@@ -117,6 +120,9 @@ exPV::expire ( const epicsTime & /*currentTime*/ ) // X aCC 361
 
 void exPV::doScan()
 {
+    if (isisdaePCASDebug > 0) {
+        std::cerr << "CAS: exPV::doScan() updating data for \"" << getName() << "\"" << std::endl;
+    }
 	try 
 	{
         this->scan();
@@ -151,7 +157,9 @@ caStatus exPV::interestRegister ()
     }
 
     this->interest = true;
-//	std::cerr << "CAS: Interest registered in PV \"" << getName() << "\"" << std::endl;
+    if (isisdaePCASDebug > 0) {
+        std::cerr << "CAS: exPV::interestRegister() in PV \"" << getName() << "\"" << std::endl;
+    }
     if ( this->scanOn && this->getScanPeriod() > 0.0 && 
             (!this->timer.getExpireInfo().active || this->getScanPeriod() < this->timer.getExpireDelay())
         ) {
@@ -167,7 +175,9 @@ caStatus exPV::interestRegister ()
 //
 void exPV::interestDelete()
 {
-//	std::cerr << "CAS: Interest unregistered in PV \"" << getName() << "\"" << std::endl;
+    if (isisdaePCASDebug > 0) {
+        std::cerr << "CAS: exPV::interestDelete() in PV \"" << getName() << "\"" << std::endl;
+    }
 	this->interest = false;
     this->timer.cancel();
 }

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -415,6 +415,22 @@ void exServer::createStandardPVs(const char* prefix, int period, int id, const c
 	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
         this->installAliasName(*pPVI, pvAlias);
 	}
+    sprintf(buffer, "%s:%d:%d:%s.HOPR", prefix, period, id, axis);
+	pPVI = createFixedPV(buffer, 0.0, "", aitEnumFloat64);
+	if (period == 1)
+	{
+        sprintf(buffer, "%s:%d:%s.HOPR", prefix, id, axis);
+	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
+        this->installAliasName(*pPVI, pvAlias);
+	}
+    sprintf(buffer, "%s:%d:%d:%s.LOPR", prefix, period, id, axis);
+	pPVI = createFixedPV(buffer, 0.0, "", aitEnumFloat64);
+	if (period == 1)
+	{
+        sprintf(buffer, "%s:%d:%s.LOPR", prefix, id, axis);
+	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
+        this->installAliasName(*pPVI, pvAlias);
+	}
 }
 
 template <typename T>

--- a/isisdaeApp/src/exServer.cc
+++ b/isisdaeApp/src/exServer.cc
@@ -327,7 +327,7 @@ void exServer::createAxisPVs(bool is_monitor, int id, int period, const char* ax
 	char buffer[256], pvAlias[256];
     const char* prefix = (is_monitor ? "MON" : "SPEC");
     sprintf(buffer, "%s:%d:%d:%s", prefix, period, id, axis);
-    pvInfo* pPVI = new pvInfo (0.5, buffer, 1.0e9f, 0.0f, units.c_str(), aitEnumFloat32, m_ntc);
+    pvInfo* pPVI = new pvInfo (0.5, buffer, 0.0f, 0.0f, units.c_str(), aitEnumFloat32, m_ntc);
     m_pvList[buffer] = pPVI;
 	SpectrumPV* pSPV = (is_monitor ? new MonitorSpectrumPV(*this, *pPVI, true, scanOn, axis, id, period) :
                                      new SpectrumPV(*this, *pPVI, true, scanOn, axis, id, period));
@@ -367,23 +367,51 @@ void exServer::createAxisPVs(bool is_monitor, int id, int period, const char* ax
 	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
         this->installAliasName(*pPVI, pvAlias);
 	}
+    createStandardPVs(prefix, period, id, axis, units, is_monitor);
+}
 
+void exServer::createStandardPVs(const char* prefix, int period, int id, const char* axis, const std::string& units, bool is_monitor)
+{
+	char buffer[256], pvAlias[256];
     sprintf(buffer, "%s:%d:%d:%s.DESC", prefix, period, id, axis);
 	std::ostringstream desc;
 	desc << axis << " (" << (is_monitor ? "mon=" : "spec=") << id << ",period=" << period << ")";
-	pPVI = createFixedPV(buffer, desc.str(), "", aitEnumString);
+	pvInfo* pPVI = createFixedPV(buffer, desc.str(), "", aitEnumString);
 	if (period == 1)
 	{
         sprintf(buffer, "%s:%d:%s.DESC", prefix, id, axis);
 	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
         this->installAliasName(*pPVI, pvAlias);
 	}
-
     sprintf(buffer, "%s:%d:%d:%s.EGU", prefix, period, id, axis);
 	pPVI = createFixedPV(buffer, units, "", aitEnumString);
 	if (period == 1)
 	{
         sprintf(buffer, "%s:%d:%s.EGU", prefix, id, axis);
+	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
+        this->installAliasName(*pPVI, pvAlias);
+	}
+    sprintf(buffer, "%s:%d:%d:%s.UDF", prefix, period, id, axis);
+	pPVI = createFixedPV(buffer, 0, "", aitEnumInt8);
+	if (period == 1)
+	{
+        sprintf(buffer, "%s:%d:%s.UDF", prefix, id, axis);
+	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
+        this->installAliasName(*pPVI, pvAlias);
+	}
+    sprintf(buffer, "%s:%d:%d:%s.STAT", prefix, period, id, axis);
+	pPVI = createNoAlarmPV(buffer);
+	if (period == 1)
+	{
+        sprintf(buffer, "%s:%d:%s.STAT", prefix, id, axis);
+	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
+        this->installAliasName(*pPVI, pvAlias);
+	}
+    sprintf(buffer, "%s:%d:%d:%s.SEVR", prefix, period, id, axis);
+	pPVI = createNoAlarmPV(buffer);
+	if (period == 1)
+	{
+        sprintf(buffer, "%s:%d:%s.SEVR", prefix, id, axis);
 	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
         this->installAliasName(*pPVI, pvAlias);
 	}
@@ -393,9 +421,21 @@ template <typename T>
 pvInfo* exServer::createFixedPV(const std::string& pvStr, const T& value, const char* units, aitEnum ait_type)
 {
 	char pvAlias[256];
-    pvInfo* pPVI = new pvInfo (0.5, pvStr.c_str(), 0.0f, 0.0f, units, ait_type, 1);   /// @todo would be nice to use arithmetic value, but need to check for strings
+    pvInfo* pPVI = new pvInfo (5.0, pvStr.c_str(), 0.0f, 0.0f, units, ait_type, 1);   /// @todo would be nice to use arithmetic value, but need to check for strings
     m_pvList[pvStr.c_str()] = pPVI;
 	exPV* pPV = new FixedValuePV<T>(*this, *pPVI, true, scanOn, value);
+    pPVI->setPV(pPV);
+	epicsSnprintf(pvAlias, sizeof(pvAlias), "%s%s", m_pvPrefix.c_str(), pvStr.c_str());
+    this->installAliasName(*pPVI, pvAlias);
+	return pPVI;
+}
+
+pvInfo* exServer::createNoAlarmPV(const std::string& pvStr)
+{
+	char pvAlias[256];
+    pvInfo* pPVI = new pvInfo (5.0, pvStr.c_str(), 0.0f, 0.0f, "", aitEnumEnum16, 1);   /// @todo would be nice to use arithmetic value, but need to check for strings
+    m_pvList[pvStr.c_str()] = pPVI;
+	exPV* pPV = new NoAlarmPV(*this, *pPVI, true, scanOn);
     pPVI->setPV(pPV);
 	epicsSnprintf(pvAlias, sizeof(pvAlias), "%s%s", m_pvPrefix.c_str(), pvStr.c_str());
     this->installAliasName(*pPVI, pvAlias);
@@ -408,7 +448,7 @@ void exServer::createCountsPV(bool is_monitor, int id, int period)
 	char buffer[256], pvAlias[256];
     const char* prefix = (is_monitor ? "MON" : "SPEC");
     sprintf(buffer, "%s:%d:%d:C", prefix, period, id);
-    pvInfo* pPVI = new pvInfo (0.5, buffer, 1.0e9f, 0.0f, "cnt", aitEnumInt32, 1);
+    pvInfo* pPVI = new pvInfo (0.5, buffer, 0.0f, 0.0f, "cnt", aitEnumInt32, 1);
     m_pvList[buffer] = pPVI;
     exPV* pPV = (is_monitor ? new MonitorCountsPV(*this, *pPVI, true, scanOn, id, period) :
                               new CountsPV(*this, *pPVI, true, scanOn, id, period));
@@ -425,27 +465,9 @@ void exServer::createCountsPV(bool is_monitor, int id, int period)
 	    sprintf(pvAlias, "%s%s.VAL", m_pvPrefix.c_str(), buffer);
         this->installAliasName(*pPVI, pvAlias);
 	}
-
-    sprintf(buffer, "%s:%d:%d:C.DESC", prefix, period, id);
-	std::ostringstream desc;
-	desc << "Integral (" << (is_monitor ? "mon=" : "spec=") << id << ",period=" << period << ")";
-	pPVI = createFixedPV(buffer, desc.str(), "", aitEnumString);
-	if (period == 1)
-	{
-        sprintf(buffer, "%s:%d:C.DESC", prefix, id);
-	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
-        this->installAliasName(*pPVI, pvAlias);
-	}
-
-    sprintf(buffer, "%s:%d:%d:C.EGU", prefix, period, id);
-	pPVI = createFixedPV(buffer, std::string("cnt"), "", aitEnumString);
-	if (period == 1)
-	{
-        sprintf(buffer, "%s:%d:C.EGU", prefix, id);
-	    sprintf(pvAlias, "%s%s", m_pvPrefix.c_str(), buffer);
-        this->installAliasName(*pPVI, pvAlias);
-	}
+    createStandardPVs(prefix, period, id, "C", "cnt", is_monitor);
 }
+
 
 bool exServer::createSpecPVs(const std::string& pvStr)
 {
@@ -491,7 +513,7 @@ bool exServer::createMonitorPVs(const std::string& pvStr)
 	createCountsPV(true, mon, period);
 
     sprintf(buffer, "MON:%d:%d:S", period, mon);
-    pvInfo* pPVI = new pvInfo (0.5, buffer, 1.0e9f, 0.0f, "", aitEnumInt32, 1);
+    pvInfo* pPVI = new pvInfo (0.5, buffer, 0.0f, 0.0f, "", aitEnumInt32, 1);
     m_pvList[buffer] = pPVI;
 	exPV* pPV = new MonLookupPV(*this, *pPVI, true, scanOn, mon);
     pPVI->setPV(pPV);

--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -423,6 +423,8 @@ class myAsyncReadIO : public casAsyncReadIO
     myAsyncReadIO(const casCtx & ctx, gdd & protoIn, exPV& pv) : casAsyncReadIO(ctx), m_pv(pv), m_ctx(ctx)
 	{
 		m_value = &protoIn;
+        // keep variable alive for use in readThread()
+        // will unreference in destructor
 		m_value->reference();
 	}
 		
@@ -437,6 +439,8 @@ class myAsyncReadIO : public casAsyncReadIO
         caStatus status, status1;
         status = m_pv.doRead(m_ctx, *m_value);
 		status1 = postIOCompletion(status, *m_value);
+        // at this point we will have had our destructor called for us
+        // so do not reference any variables in "this"
         if (status1 != S_casApp_success)
            std::cerr << "CAS: Error returned by postIOCompletion" << std::endl;
 	}

--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -424,10 +424,9 @@ class myAsyncReadIO : public casAsyncReadIO
 	{
 		m_value = &protoIn;
 		m_value->reference();
-	    epicsThreadCreate("myAsyncReadIO", epicsThreadPriorityMedium, epicsThreadStackMedium, readThread, this); 
 	}
 		
-    static void readThread(void* arg)
+    static void readThreadC(void* arg)
     {
 		myAsyncReadIO* aio = (myAsyncReadIO*)arg;
 		aio->readThread();
@@ -441,6 +440,13 @@ class myAsyncReadIO : public casAsyncReadIO
         if (status1 != S_casApp_success)
            std::cerr << "CAS: Error returned by postIOCompletion" << std::endl;
 	}
+    ~myAsyncReadIO()
+    {
+        m_value->unreference();
+        m_value = NULL;
+    }
+
+
 };
 
 //

--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -664,3 +664,4 @@ inline exChannel::exChannel ( const casCtx & ctxIn ) :
 {
 }
 
+extern "C" int isisdaePCASDebug;

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -2685,6 +2685,8 @@ int isisdaeConfigure(const char *portName, int options, const char *host, const 
 
 volatile bool isisdaeDriver::daeIOCisRunning = false;
 
+int isisdaePCASDebug = 0;
+
 void isisdaeDriver::waitForIOCRunning()
 {
 	while (!daeIOCisRunning)
@@ -2792,5 +2794,6 @@ static void isisdaeRegister(void)
 }
 
 epicsExportRegistrar(isisdaeRegister);
+epicsExportAddress(int, isisdaePCASDebug);
 
 }

--- a/isisdaeApp/src/isisdaeInclude.dbd
+++ b/isisdaeApp/src/isisdaeInclude.dbd
@@ -1,1 +1,2 @@
 registrar("isisdaeRegister")
+variable(isisdaePCASDebug, int)


### PR DESCRIPTION
* Add SEVR STAT and UDF fields to data arrays
* Do not slow scan PVs that are not being monitored
* Reduce scan rate on fixed pvs that do not change
* Remove alarm level limits on axis PVs

See ISISComputingGroup/IBEX#7216
 