### PR TITLE
Add crpt spectrum reads via PV

### DIFF
--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -907,6 +907,27 @@ record(longout, "$(P)$(Q)FCPERIOD:SP")
     field(UDFS, "NO_ALARM")
 }
 
+record(calc, "$(P)$(Q)NUMPERIODS:MAX")
+{
+    field(DESC, "Max Num DAE periods")
+    field(INPA, "$(P)$(Q)NUMSPECTRA CP")
+    field(INPB, "$(P)$(Q)NUMTIMECHANNELS CP")
+    field(INPC, "$(P)$(Q)CRPTDATAWORDS CP")
+    field(EGU, "")
+    field(CALC, "C / ((A + 1) * (B + 1))")
+    field(ASG, "READONLY")
+}
+
+record(longin, "$(P)$(Q)CRPTDATAWORDS")
+{
+    field(DESC, "CRTP size in 4 byte words")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn(icp,0,0)CRPTDATAWORDS")
+    field(SCAN, "I/O Intr")
+    field(UDFS, "NO_ALARM")
+    field(EGU, "")
+}
+
 record(longin, "$(P)$(Q)NUMPERIODS")
 {
     field(DESC, "Number of DAE periods")

--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -914,7 +914,7 @@ record(calc, "$(P)$(Q)NUMPERIODS:MAX")
     field(INPB, "$(P)$(Q)NUMTIMECHANNELS CP")
     field(INPC, "$(P)$(Q)CRPTDATAWORDS CP")
     field(EGU, "")
-    field(CALC, "C / ((A + 1) * (B + 1))")
+    field(CALC, "FLOOR(C / ((A + 1) * (B + 1)))")
     field(ASG, "READONLY")
 }
 

--- a/isisdaeApp/src/CountsPV.cpp
+++ b/isisdaeApp/src/CountsPV.cpp
@@ -6,7 +6,7 @@
 #include "gddApps.h"
 #include "isisdaeInterface.h"
 
-CountsPV::CountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int spec, int period ) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, true), m_spec(spec), m_period(period)
+CountsPV::CountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int spec, int period, bool use_crpt) : exScalarPV(cas, setup, preCreateFlag, scanOnIn, true), m_spec(spec), m_period(period), m_use_crpt(use_crpt)
 {
 
 }
@@ -16,7 +16,11 @@ bool CountsPV::getNewValue(smartGDDPointer& pDD)
 {
     long counts = 0;
 	try {
-        cas.iface()->getSpectrumIntegral(m_spec, m_period, 0.0, -1.0, counts);
+        if (m_use_crpt) {
+            cas.iface()->getCRPTSpectrumIntegral(m_spec, m_period, 0.0, -1.0, counts);
+        } else {
+            cas.iface()->getSpectrumIntegral(m_spec, m_period, 0.0, -1.0, counts);
+        }
 	}
 	catch(const std::exception& ex) {
 		std::cerr << "CAS: Exception in CountsPV::getNewValue(): " << ex.what() << std::endl;

--- a/isisdaeApp/src/MonitorCountsPV.cpp
+++ b/isisdaeApp/src/MonitorCountsPV.cpp
@@ -3,8 +3,8 @@
 
 #include "isisdaeInterface.h"
 
-MonitorCountsPV::MonitorCountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int mon, int period ) :
-            CountsPV(cas, setup, preCreateFlag, scanOnIn, 0/*spec*/, period), m_monitor(mon)
+MonitorCountsPV::MonitorCountsPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, int mon, int period, bool use_crpt) :
+            CountsPV(cas, setup, preCreateFlag, scanOnIn, 0/*spec*/, period, use_crpt), m_monitor(mon)
 {
     updateSpectrum();
 }

--- a/isisdaeApp/src/MonitorSpectrumPV.cpp
+++ b/isisdaeApp/src/MonitorSpectrumPV.cpp
@@ -3,8 +3,8 @@
 
 #include "isisdaeInterface.h"
 
-MonitorSpectrumPV::MonitorSpectrumPV(exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int mon, int period) :
-        SpectrumPV(cas, setup, preCreateFlag, scanOnIn, axis, 0/*spec*/, period), m_monitor(mon)
+MonitorSpectrumPV::MonitorSpectrumPV(exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int mon, int period, bool use_crpt) :
+        SpectrumPV(cas, setup, preCreateFlag, scanOnIn, axis, 0/*spec*/, period, use_crpt), m_monitor(mon)
 {
     updateSpectrum();
 }

--- a/isisdaeApp/src/SpectrumPV.cc
+++ b/isisdaeApp/src/SpectrumPV.cc
@@ -8,9 +8,9 @@
 /// class for a spectrum. This is a fixed size channel access array, but its current size is stored in m_nord and exported as a .NORD field via  
 /// the #NORDPV class. It thus looks a bit like an EPICS Waveform record and, like waveform, export an NELM field too.   
 
-SpectrumPV::SpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int spec, int period )
+SpectrumPV::SpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int spec, int period, bool use_crpt)
 	   : exVectorPV(cas, setup, preCreateFlag, scanOnIn, true), m_axis(axis), m_spec(spec),
-       m_period(period), m_nord(0), m_minval(0.0), m_maxval(0.0)
+       m_period(period), m_nord(0), m_minval(0.0), m_maxval(0.0), m_use_crpt(use_crpt)
 {
 
 }
@@ -38,11 +38,19 @@ bool SpectrumPV::getNewValue(smartGDDPointer& pDD)
 	try {
 	    if (m_axis == "YC")
 		{
-	        n = cas.iface()->getSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            if (m_use_crpt) {
+	            n = cas.iface()->getCRPTSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            } else {
+	            n = cas.iface()->getSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            }
 		}
 		else
 		{
-	        n = cas.iface()->getSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            if (m_use_crpt) {
+	            n = cas.iface()->getCRPTSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            } else {
+	            n = cas.iface()->getSpectrum(m_spec, m_period, pX, pY, nmax, as_histogram, as_distribution);
+            }
 		}
 	}
 	catch(const std::exception& ex) {

--- a/isisdaeApp/src/exServer.h
+++ b/isisdaeApp/src/exServer.h
@@ -61,8 +61,8 @@
 #endif
 
 // 0x0 on error, 0x1 for scalar int, 0x2 for scalar float, 0x4 for string, ored with 0x100 if array
-bool parseSpecPV(const std::string& pvStr, int& spec, int& period, std::string& axis, std::string& field);
-bool parseMonitorPV(const std::string& pvStr, int& mon, int& period, std::string& axis, std::string& field);
+bool parseSpecPV(const std::string& pvStr, int& spec, int& period, std::string& axis, std::string& field, bool& use_crpt);
+bool parseMonitorPV(const std::string& pvStr, int& mon, int& period, std::string& axis, std::string& field, bool& use_crpt);
 //int parseSamplePV(const std::string& pvStr, std::string& param); 
 //int parseBeamlinePV(const std::string& pvStr, std::string& param); 
 
@@ -329,12 +329,13 @@ private:
 class CountsPV : public exScalarPV {
 public:
     CountsPV ( exServer & cas, pvInfo &setup, 
-        bool preCreateFlag, bool scanOnIn, int spec, int period );
+        bool preCreateFlag, bool scanOnIn, int spec, int period, bool use_crpt);
 	virtual bool getNewValue(smartGDDPointer& pDD);
 protected:
     int m_spec;  // so can be updated by MonitorCountsPV subclass 
 private:
 	int m_period;
+    bool m_use_crpt;
     CountsPV & operator = ( const CountsPV & );
     CountsPV ( const CountsPV & );
 };
@@ -342,7 +343,7 @@ private:
 class MonitorCountsPV : public CountsPV {
 public:
     MonitorCountsPV ( exServer & cas, pvInfo &setup, 
-        bool preCreateFlag, bool scanOnIn, int mon, int period );
+        bool preCreateFlag, bool scanOnIn, int mon, int period, bool use_crpt);
 	virtual bool getNewValue(smartGDDPointer& pDD);
 private:
 	int m_monitor;
@@ -420,7 +421,7 @@ class exVecDestructor: public gddDestructor {
 
 class SpectrumPV : public exVectorPV {
 public:
-    SpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int spec, int period);
+    SpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int spec, int period, bool use_crpt);
 	virtual bool getNewValue(smartGDDPointer& pDD);
     int& getNORD() { return m_nord; }
     float& getMAXVAL() { return m_maxval; }
@@ -433,13 +434,14 @@ private:
 	int m_nord;
 	float m_maxval;
 	float m_minval;
+    bool m_use_crpt;
     SpectrumPV & operator = ( const SpectrumPV & );
     SpectrumPV ( const SpectrumPV & );
 };
 
 class MonitorSpectrumPV : public SpectrumPV {
 public:
-    MonitorSpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int mon, int period);
+    MonitorSpectrumPV ( exServer & cas, pvInfo &setup, bool preCreateFlag, bool scanOnIn, const std::string& axis, int mon, int period, bool use_crpt);
 	virtual bool getNewValue(smartGDDPointer& pDD);
 private:
     int m_monitor;
@@ -516,8 +518,8 @@ public:
 	
 	bool createSpecPVs(const std::string& pvStr);
 	bool createMonitorPVs(const std::string& pvStr);
-	void createAxisPVs(bool is_monitor, int id, int period, const char* axis, const std::string& units);
-	void createCountsPV(bool is_monitor, int id, int period);
+	void createAxisPVs(bool use_crpt, bool is_monitor, int id, int period, const char* axis, const std::string& units);
+	void createCountsPV(bool use_crpt, bool is_monitor, int id, int period);
     template <typename T> pvInfo* createFixedPV(const std::string& pvStr, const T& value, const char* units, aitEnum ait_type);
     pvInfo* createNoAlarmPV(const std::string& pvStr);
 private:

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -1231,6 +1231,7 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName, int 
     
     createParam(P_blockSpecZeroString, asynParamInt32, &P_blockSpecZero);
     createParam(P_setRunNumberString, asynParamInt32, &P_setRunNumber);
+    createParam(P_CRPTDataWordsString, asynParamInt32, &P_CRPTDataWords);
     
     createParam(P_spectrumIntegralsString, asynParamInt32Array, &P_spectrumIntegrals);
     createParam(P_spectrumDataString, asynParamInt32Array, &P_spectrumData);
@@ -1569,6 +1570,7 @@ void isisdaeDriver::pollerThread2()
                 m_iface->getTCBSettingsXML(tcbSettings);
                 m_iface->getHardwarePeriodsSettingsXML(hardwarePeriodsSettings);
                 m_iface->getUpdateSettingsXML(updateSettings);
+                setIntegerParam(P_CRPTDataWords, m_iface->getCRPTDataWords());
             }
             this_gf = m_iface->getGoodFrames();
 		    m_iface->getVetoInfo(veto_names, veto_aliases, veto_enabled, veto_frames);

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -179,6 +179,7 @@ private:
     
     int P_blockSpecZero; // long
     int P_setRunNumber; // long
+    int P_CRPTDataWords; // long
     int P_AllMsgs; // char
     int P_ErrMsgs; // char
 	#define LAST_ISISDAE_PARAM P_ErrMsgs
@@ -362,6 +363,8 @@ private:
 
 #define P_blockSpecZeroString                "BLOCKSPECZERO"
 #define P_setRunNumberString                 "SET_RUNNUMBER"
+
+#define P_CRPTDataWordsString                "CRPTDATAWORDS"
 
 #define P_AllMsgsString	"ALLMSGS"
 #define P_ErrMsgsString	"ERRMSGS"

--- a/isisdaeApp/src/isisdaeInterface.cpp
+++ b/isisdaeApp/src/isisdaeInterface.cpp
@@ -618,6 +618,12 @@ long isisdaeInterface::getDAEType()
     return atol(getValue("DAETYPE").c_str());
 }
 
+
+long isisdaeInterface::getCRPTDataWords()
+{
+    return atol(getValue("CRPTDATASIZE").c_str());
+}
+
 std::string isisdaeInterface::getValue(const std::string& name)
 {
     if (m_dcom)

--- a/isisdaeApp/src/isisdaeInterface.cpp
+++ b/isisdaeApp/src/isisdaeInterface.cpp
@@ -1090,13 +1090,29 @@ long isisdaeInterface::getSpectrumSize(long spectrum_number)
 }
 
 // returns number of signal values, if as_histogram is true them there will be n+1 time bin boundary values rather than n 
+long isisdaeInterface::getCRPTSpectrum(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution)
+{
+    return getSpectrumHelper(spec, period, time_channels, signal, nvals, as_histogram, as_distribution, true);
+}
+
+// returns number of signal values, if as_histogram is true them there will be n+1 time bin boundary values rather than n 
 long isisdaeInterface::getSpectrum(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution)
+{
+    return getSpectrumHelper(spec, period, time_channels, signal, nvals, as_histogram, as_distribution, false);
+}
+
+// returns number of signal values, if as_histogram is true them there will be n+1 time bin boundary values rather than n 
+long isisdaeInterface::getSpectrumHelper(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution, bool use_crpt)
 {
 	long sum = 0, n;
 	if (m_dcom)
 	{
 		variant_t time_channels_v, signal_v;
-		callD<int>(boost::bind(&ICPDCOM::getSpectrum, _1, spec, period, &time_channels_v, &signal_v, as_histogram, as_distribution, &sum, _2));
+        if (use_crpt) {
+		    callD<int>(boost::bind(&ICPDCOM::getCRPTSpectrum, _1, spec, period, &time_channels_v, &signal_v, as_histogram, as_distribution, &sum, _2));
+        } else {
+		    callD<int>(boost::bind(&ICPDCOM::getSpectrum, _1, spec, period, &time_channels_v, &signal_v, as_histogram, as_distribution, &sum, _2));
+        }
 		double *s = NULL, *t = NULL;
 		accessArrayVariant(&signal_v, &s);
 		accessArrayVariant(&time_channels_v, &t);
@@ -1131,6 +1147,24 @@ long isisdaeInterface::getSpectrum(int spec, int period, float* time_channels, f
     return n;
 }
 
+long isisdaeInterface::getCRPTSpectrumIntegral(long spectrum_number, long period, float time_low, float time_high, long& counts)
+{
+	variant_t spectrum_numbers_v, times_low_v, times_high_v, counts_v;
+    std::vector<long> spectrum_numbers = { spectrum_number };
+    std::vector<float> times_low = { time_low };
+    std::vector<float> times_high = { time_high };
+    std::vector<long> counts_array;
+	makeVariantFromArray(&spectrum_numbers_v, spectrum_numbers);
+	makeVariantFromArray(&times_low_v, times_low);
+	makeVariantFromArray(&times_high_v, times_high);
+	if (m_dcom) {
+		callD<int>(boost::bind(&ICPDCOM::getCRPTSpectraIntegral, _1, spectrum_numbers_v, period, times_low_v, times_high_v, &counts_v, _2));
+		makeArrayFromVariant(counts_array, &counts_v);
+        counts = (counts_array.size() > 0 ? counts_array[0] : 0);
+    }
+    return 0;
+}
+
 long isisdaeInterface::getSpectrumIntegral(long spectrum_number, long period, float time_low, float time_high, long& counts)
 {
 	if (m_dcom)
@@ -1147,6 +1181,9 @@ long isisdaeInterface::getSpectrumIntegral(long spectrum_number, long period, fl
 long isisdaeInterface::getSpectrumIntegral(std::vector<long>& spectrum_numbers, long period, std::vector<float>& times_low, std::vector<float>& times_high, std::vector<long>& counts)
 {
 	variant_t spectrum_numbers_v, times_low_v, times_high_v, counts_v;
+	makeVariantFromArray(&spectrum_numbers_v, spectrum_numbers);
+	makeVariantFromArray(&times_low_v, times_low);
+	makeVariantFromArray(&times_high_v, times_high);
 	if (m_dcom)
 	{
 		callD<int>(boost::bind(&ICPDCOM::getSpectraIntegral, _1, spectrum_numbers_v, period, times_low_v, times_high_v, &counts_v, _2));

--- a/isisdaeApp/src/isisdaeInterface.h
+++ b/isisdaeApp/src/isisdaeInterface.h
@@ -110,8 +110,10 @@ public:
     int getPeriod();
     long getNumPeriods();
 	long getSpectrum(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution);
+	long getCRPTSpectrum(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution);
     long getSpectrumSize(long spectrum_number);
     long getSpectrumIntegral(long spectrum_number, long period, float time_low, float time_high, long& counts);
+    long getCRPTSpectrumIntegral(long spectrum_number, long period, float time_low, float time_high, long& counts);
     long getSpectrumIntegral(std::vector<long>& spectrum_numbers, long period, std::vector<float>& times_low, std::vector<float>& times_high, std::vector<long>& counts);
     long getSpectrumIntegral2(long spec_start, long nspectra, long period, float time_low, float time_high, std::vector<long>& counts);
 	int updateCRPTSpectra(long period, long spec_start, long nspectra);
@@ -195,6 +197,7 @@ private:
   
 	int getXMLSettingsI(std::string& result, const std::string& template_file, int (*func)(const std::string&, std::string&, std::string&));
     int getXMLSettingsD(std::string& result, const std::string& template_file, HRESULT (ICPDCOM::*func)(_bstr_t, BSTR*, BSTR*));
+	long getSpectrumHelper(int spec, int period, float* time_channels, float* signal, long nvals, bool as_histogram, bool as_distribution, bool use_crpt);
 };
 
 #endif /* ISISDAE_INTERFACE_H */

--- a/isisdaeApp/src/isisdaeInterface.h
+++ b/isisdaeApp/src/isisdaeInterface.h
@@ -157,6 +157,7 @@ public:
 	long getSpectrumNumberForMonitor(long mon_num);
 	int setICPValue(const std::string& name, const std::string& value);
 	int setICPValueLong(const std::string& name, long value);
+    long getCRPTDataWords();
 	typedef isisicpLib::Idae ICPDCOM;
 	
 private:

--- a/isisdaeApp/src/isisicp.tlh
+++ b/isisdaeApp/src/isisicp.tlh
@@ -1,9 +1,9 @@
-﻿// Created by Microsoft (R) C/C++ Compiler Version 14.00.24247.2 (f732dba8).
+﻿// Created by Microsoft (R) C/C++ Compiler Version 14.41.34123.0 (d1a4bee2).
 //
-// c:\development\instrumentcontrol\icp\isisicp\x64\debug\isisicp.tlh
+// C:\development\InstrumentControl\ICP\isisicp\x64\Release\isisicp.tlh
 //
 // C++ source equivalent of type library isisicp.tlb
-// compiler-generated file created 09/10/24 at 17:25:34 - DO NOT EDIT!
+// compiler-generated file - DO NOT EDIT!
 
 #pragma once
 #pragma pack(push, 8)
@@ -393,6 +393,15 @@ Idae : IDispatch
     long getSpectrumSize (
         long spectrum_number,
         BSTR * messages );
+    HRESULT getCRPTSpectrum (
+        long spectrum_number,
+        long period,
+        VARIANT * time_channels,
+        VARIANT * signal,
+        long as_histogram,
+        long as_distribution,
+        long * sum,
+        BSTR * messages );
 
     //
     // Raw methods provided by interface
@@ -759,6 +768,15 @@ Idae : IDispatch
         /*[in]*/ long spectrum_number,
         /*[out]*/ BSTR * messages,
         /*[out,retval]*/ long * value ) = 0;
+      virtual HRESULT __stdcall raw_getCRPTSpectrum (
+        /*[in]*/ long spectrum_number,
+        /*[in]*/ long period,
+        /*[out]*/ VARIANT * time_channels,
+        /*[out]*/ VARIANT * signal,
+        /*[in]*/ long as_histogram,
+        /*[in]*/ long as_distribution,
+        /*[out]*/ long * sum,
+        /*[out]*/ BSTR * messages ) = 0;
 };
 
 //

--- a/isisdaeApp/src/isisicp.tli
+++ b/isisdaeApp/src/isisicp.tli
@@ -1,9 +1,9 @@
-﻿// Created by Microsoft (R) C/C++ Compiler Version 14.00.24247.2 (f732dba8).
+﻿// Created by Microsoft (R) C/C++ Compiler Version 14.41.34123.0 (d1a4bee2).
 //
-// c:\development\instrumentcontrol\icp\isisicp\x64\debug\isisicp.tli
+// C:\development\InstrumentControl\ICP\isisicp\x64\Release\isisicp.tli
 //
 // Wrapper implementations for type library isisicp.tlb
-// compiler-generated file created 09/10/24 at 17:25:34 - DO NOT EDIT!
+// compiler-generated file - DO NOT EDIT!
 
 #pragma once
 
@@ -594,4 +594,10 @@ inline long Idae::getSpectrumSize ( long spectrum_number, BSTR * messages ) {
     HRESULT _hr = raw_getSpectrumSize(spectrum_number, messages, &_result);
     if (FAILED(_hr)) _com_issue_errorex(_hr, this, __uuidof(this));
     return _result;
+}
+
+inline HRESULT Idae::getCRPTSpectrum ( long spectrum_number, long period, VARIANT * time_channels, VARIANT * signal, long as_histogram, long as_distribution, long * sum, BSTR * messages ) {
+    HRESULT _hr = raw_getCRPTSpectrum(spectrum_number, period, time_channels, signal, as_histogram, as_distribution, sum, messages);
+    if (FAILED(_hr)) _com_issue_errorex(_hr, this, __uuidof(this));
+    return _hr;
 }


### PR DESCRIPTION
Add reading of CRPT spectra stored by an isisicp update command. These are read using names line CSPEC:1:1:Y rather than SPEC:1:1:Y and their value reflects that loaded from the dae by the last update() or updatestore() operation.

am updated and re-registered isisicp is required

  