### PR TITLE
Add end time PV

### DIFF
--- a/isisdaeApp/Db/isisdae.db
+++ b/isisdaeApp/Db/isisdae.db
@@ -219,6 +219,16 @@ record(ai, "$(P)$(Q)STOP_TIME")
 }
 
 ## time_t (seconds since 01-01-1970)
+record(ai, "$(P)$(Q)END_TIME")
+{
+    field(DESC, "Run End Time")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn(icp,0,0)END_TIME")
+    field(SCAN, "I/O Intr")
+    info(archive, "VAL")
+}
+
+## time_t (seconds since 01-01-1970)
 record(ai, "$(P)$(Q)RESUME_TIME")
 {
     field(DESC, "Run Resume Time")
@@ -227,8 +237,6 @@ record(ai, "$(P)$(Q)RESUME_TIME")
     field(SCAN, "I/O Intr")
     info(archive, "VAL")
 }
-
-
 
 record(ai, "$(P)$(Q)NPRATIO")
 {

--- a/isisdaeApp/src/isisdaeDriver.cpp
+++ b/isisdaeApp/src/isisdaeDriver.cpp
@@ -1240,6 +1240,7 @@ isisdaeDriver::isisdaeDriver(isisdaeInterface* iface, const char *portName, int 
     createParam(P_autosaveFreqString, asynParamInt32, &P_autosaveFreq);
     createParam(P_startTimeString, asynParamFloat64, &P_startTime);
     createParam(P_stopTimeString, asynParamFloat64, &P_stopTime);
+    createParam(P_endTimeString, asynParamFloat64, &P_endTime);
     createParam(P_resumeTimeString, asynParamFloat64, &P_resumeTime);
     
     createParam(P_spectrumIntegralsString, asynParamInt32Array, &P_spectrumIntegrals);
@@ -1494,6 +1495,7 @@ void isisdaeDriver::updateRunStatus()
         
         setDoubleParam(P_startTime, std::stod(m_iface->getValue("DSTARTTIME")));
         setDoubleParam(P_stopTime, std::stod(m_iface->getValue("DSTOPTIME")));
+        setDoubleParam(P_endTime, std::stod(m_iface->getValue("DENDTIME")));
         setDoubleParam(P_resumeTime, std::stod(m_iface->getValue("DRESUMETIME")));
         
         ///@todo need to update P_RunDurationTotal, P_RunDurationPeriod, P_MonitorCounts

--- a/isisdaeApp/src/isisdaeDriver.h
+++ b/isisdaeApp/src/isisdaeDriver.h
@@ -116,6 +116,7 @@ private:
 	int P_inChangingState; // int
     int P_startTime; //double
     int P_stopTime; //double
+    int P_endTime; //double
     int P_resumeTime; //double
 
     int P_VMEReadValueProps; // int array
@@ -373,6 +374,7 @@ private:
 #define P_CRPTDataWordsString                "CRPTDATAWORDS"
 #define P_startTimeString                "START_TIME"
 #define P_stopTimeString                "STOP_TIME"
+#define P_endTimeString                "END_TIME"
 #define P_resumeTimeString                "RESUME_TIME"
 
 


### PR DESCRIPTION
Needs latest ISISICP build - if you run isisicp from `EPICS\icp_binaries` just run `create_icp_binaries.bat` in your EPCS area

if you run isisicp from `labview modules\dae`  run `update_inst.bat`  from latest `Kits$\CompGroup\ICP\ISISICP\DAE2` folder 

## To Test

* new `END_TIME` PV should update to end time of run in seconds since 1970  at run end and not change due to pause/resume/abort.
* on begin `END_TIME`  is reset to 0
